### PR TITLE
Add support for fans

### DIFF
--- a/api/location.ts
+++ b/api/location.ts
@@ -43,6 +43,7 @@ export class RingDevice {
   zid = this.initialData.zid
   id = this.zid
   deviceType = this.initialData.deviceType
+  categoryId = this.initialData.categoryId
 
   constructor(
     private initialData: RingDeviceData,

--- a/api/ring-types.ts
+++ b/api/ring-types.ts
@@ -14,12 +14,18 @@ export enum RingDeviceType {
   CoAlarm = 'alarm.co',
   SmokeCoListener = 'listener.smoke-co',
   MultiLevelSwitch = 'switch.multilevel',
+  Fan = 'switch.multilevel',
   MultiLevelBulb = 'switch.multilevel.bulb',
   Switch = 'switch',
   BeamsMotionSensor = 'motion-sensor.beams',
   BeamsSwitch = 'switch.multilevel.beams',
   BeamsLightGroupSwitch = 'group.light-group.beams',
   BeamsTransformerSwitch = 'switch.transformer.beams'
+}
+
+export enum RingDeviceCategory {
+  Fan = 17,
+  MultiLevelSwitch = 2
 }
 
 export enum RingCameraKind {
@@ -123,6 +129,7 @@ export interface RingDeviceData {
   zid: string
   name: string
   deviceType: RingDeviceType
+  categoryId: number
   batteryLevel?: number
   batteryStatus: 'full' | 'charged' | 'ok' | 'low' | 'none' | 'charging'
   batteryBackup?: 'charged' | 'charging' | 'inUse'

--- a/homebridge/README.md
+++ b/homebridge/README.md
@@ -1,35 +1,35 @@
 # homebridge-ring
- 
+
 [![CircleCI](https://circleci.com/gh/dgreif/ring.svg?style=svg)](https://circleci.com/gh/dgreif/ring)
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=HD9ZPB34FY428&currency_code=USD&source=url)
- 
+
 This [Homebridge](https://github.com/nfarina/homebridge) plugin provides a platform for
 [Ring Doorbells](https://shop.ring.com/pages/doorbell-cameras),
 [Ring Cameras](https://shop.ring.com/pages/security-cameras),
 the [Ring Alarm System](https://shop.ring.com/pages/security-system),
 [Ring Smart Lighting](https://shop.ring.com/pages/smart-lighting),
 and third party devices that connect to the Ring Alarm System.
- 
+
  ## Installation
- 
+
  Assuming a global installation of `homebridge`:
- 
+
  `npm i -g homebridge-ring`
- 
+
  ## Homebridge Configuration
- 
+
  Add the `Ring` platform in your homebridge `config.json` file.
- 
+
  ```js
 {
   "platforms": [
     {
       "platform": "Ring",
-      
+
       // without 2fa
       email: 'some.one@website.com',
       password: 'abc123!#',
-      
+
       // with 2fa or if you don't want to store your email/password in your config
       refreshToken: 'token generated with ring-auth-cli.  See https://github.com/dgreif/ring/wiki/Two-Factor-Auth',
 
@@ -43,7 +43,7 @@ and third party devices that connect to the Ring Alarm System.
       "hideAlarmSirenSwitch": true,
       "cameraStatusPollingSeconds": 20,
       "cameraDingsPollingSeconds": 2,
-      "locationIds": ["488e4800-fcde-4493-969b-d1a06f683102", "4bbed7a7-06df-4f18-b3af-291c89854d60"]         
+      "locationIds": ["488e4800-fcde-4493-969b-d1a06f683102", "4bbed7a7-06df-4f18-b3af-291c89854d60"]
     }
   ]
 }
@@ -52,7 +52,7 @@ and third party devices that connect to the Ring Alarm System.
 For accounts with 2fa enabled, see the [Two Factor Auth Wiki](https://github.com/dgreif/ring/wiki/Two-Factor-Auth)
 
 ### Optional Parameters
-Only include an optional parameter if you actually need it.  Default behavior 
+Only include an optional parameter if you actually need it.  Default behavior
 without any of the optional parameters should be sufficient for most users.
 
 Option | Default | Explanation
@@ -66,8 +66,8 @@ Option | Default | Explanation
 `hideCameraSirenSwitch` | `false` | If `true`, hides the siren switch for Ring cameras in HomeKit.
 `hideAlarmSirenSwitch` | `false` | If you have a Ring Alarm, you will see both the alarm and a "Siren" switch in HomeKit.  The siren switch can sometimes get triggered by Siri commands by accident, which is loud and annoying.  Set this option to `true` to hide the siren switch.
 `cameraStatusPollingSeconds` | `20` | How frequently to poll for updates to your cameras.  Information like light/siren status do not update in real time and need to be requested periodically.
-`cameraDingsPollingSeconds` | `2` | How frequently to poll for new events from your cameras.  These include motion and doorbell presses. 
-`locationIds` | All Locations | Use this option if you only want a subset of your locations to appear in HomeKit. If this option is not included, all of your locations will be added to HomeKit (which is what most users will want to do).  
+`cameraDingsPollingSeconds` | `2` | How frequently to poll for new events from your cameras.  These include motion and doorbell presses.
+`locationIds` | All Locations | Use this option if you only want a subset of your locations to appear in HomeKit. If this option is not included, all of your locations will be added to HomeKit (which is what most users will want to do).
 
 ### Camera Setup
 
@@ -76,7 +76,7 @@ Don't worry, it's really easy. Due to homebridge/HAP limitations, the cameras ca
 Configure the homebridge plugin like normal, then click on the "+" in the upper right in
 the Home app, then "Don't have a Code or Can't Scan?", then you should see the cameras listed as individual devices which
 which you can add.  The code that you need for each is the same code you used when setting up homebridge.  It should be in
-the output when you start homebridge, or in your homebridge `config.json` file. 
+the output when you start homebridge, or in your homebridge `config.json` file.
 Walk through the setup pages and when you are done, you should see several devices related to the camera:
 
   * Camera Feed
@@ -99,7 +99,7 @@ If you turn on notifications for the motion sensors, or for any doorbell camera,
 HomeKit with a snapshot from the camera
 
 If you are having issues with your cameras in the Home app, please see the [Camera Troubleshooting Wiki](https://github.com/dgreif/ring/wiki/Camera-Troubleshooting)
-  
+
 ### Supported Devices via Ring Alarm and Ring Smart Lighting Hubs
   * Security Panel
     * This is a software device that represents the alarm for a Ring location
@@ -129,6 +129,9 @@ If you are having issues with your cameras in the Home app, please see the [Came
   * Carbon Monoxide Alarm
   * Smoke/Carbon Monoxide Listener
   * Smart Locks
+  * Fans
+    * On/Off
+    * Speed
   * Lights/Switches
     * On/Off
     * Brightness Level (if applicable)
@@ -149,7 +152,7 @@ Entry delays and bypassed sensors (ex. for Home mode) are all controlled in the 
 These settings will automatically be used by HomeKit.
 
 **Note**: Using `Night` mode in HomeKit will activate `Home` mode on the Ring alarm.
-HomeKit should immediately switch to `Home` to match.  
+HomeKit should immediately switch to `Home` to match.
 
 ### Siri Commands for Alarm
 

--- a/homebridge/fan.ts
+++ b/homebridge/fan.ts
@@ -1,0 +1,48 @@
+import { BaseDeviceAccessory } from './base-device-accessory'
+import { RingDevice } from '../api'
+import { HAP, hap } from './hap'
+import { RingPlatformConfig } from './config'
+
+export class Fan extends BaseDeviceAccessory {
+  constructor(
+    public readonly device: RingDevice,
+    public readonly accessory: HAP.Accessory,
+    public readonly logger: HAP.Log,
+    public readonly config: RingPlatformConfig
+  ) {
+    super()
+
+    const { Characteristic, Service } = hap
+    const { data: initialData } = this.device
+
+    this.registerCharacteristic(
+      Characteristic.On,
+      Service.Fan,
+      data => Boolean(data.on),
+      value => this.setOnState(value)
+    )
+
+    if (initialData.level !== undefined) {
+      this.registerLevelCharacteristic(
+        Characteristic.RotationSpeed,
+        Service.Fan,
+        data => (data.level && !isNaN(data.level) ? 100 * data.level : 0),
+        value => this.setLevelState(value)
+      )
+    }
+  }
+
+  setOnState(on: boolean) {
+    this.logger.info(`Turning ${this.device.name} ${on ? 'On' : 'Off'}`)
+
+    return this.device.setInfo({ device: { v1: { on } } })
+  }
+
+  setLevelState(level: number) {
+    this.logger.info(`Setting speed of ${this.device.name} to ${level}%`)
+
+    return this.device.setInfo({
+      device: { v1: { level: level / 100 } }
+    })
+  }
+}

--- a/homebridge/ring-platform.ts
+++ b/homebridge/ring-platform.ts
@@ -1,4 +1,10 @@
-import { RingApi, RingCamera, RingDevice, RingDeviceType } from '../api'
+import {
+  RingApi,
+  RingCamera,
+  RingDevice,
+  RingDeviceType,
+  RingDeviceCategory
+} from '../api'
 import { HAP, hap } from './hap'
 import { SecurityPanel } from './security-panel'
 import { BaseStation } from './base-station'
@@ -12,6 +18,7 @@ import { SmokeCoListener } from './smoke-co-listener'
 import { RingPlatformConfig } from './config'
 import { Beam } from './beam'
 import { MultiLevelSwitch } from './multi-level-switch'
+import { Fan } from './fan'
 import { Switch } from './switch'
 import { Camera } from './camera'
 import { RingAuth } from '../api/rest-client'
@@ -48,6 +55,10 @@ function getAccessoryClass(device: RingDevice | RingCamera) {
     case RingDeviceType.BeamsLightGroupSwitch:
       return Beam
     case RingDeviceType.MultiLevelSwitch:
+      return device instanceof RingDevice &&
+        device.categoryId === RingDeviceCategory.Fan
+        ? Fan
+        : MultiLevelSwitch
     case RingDeviceType.MultiLevelBulb:
       return MultiLevelSwitch
     case RingDeviceType.Switch:


### PR DESCRIPTION
Fan control switches, such as the [GE 14287](https://byjasco.com/products/ge-z-wave-plus-wall-smart-fan-control), can be added to the Ring Alarm Base Station via “Devices > Set Up a Device > Security Devices > Works With Ring”.

Once the device is added, the Ring app prompts you to select a category (options are “Fans”, “Lights” and “Outlets”) (screenshot below):
![IMG](https://user-images.githubusercontent.com/3104489/62417252-66676300-b619-11e9-9fa7-c1f286796f38.PNG)

Homebridge supports a [`Fan` Service](https://github.com/KhaosT/HAP-NodeJS/blob/c11776dc4a145381228ecfadb47dd583977e367d/lib/gen/HomeKitTypes.js#L2881-L2899). This PR enables the `homebridge-ring` plugin to identify fan control devices as Fans to HomeKit.

Without this PR, the plugin identifies these devices as dimmable lights. This is because Ring reuses the `switch.multilevel` `deviceType` for both fans and (multi-level) switches. This PR differentiates the two device types by using the value of `categoryId`. Fans and multi-level switches have `categoryId` `17` and `2`, respectively. This can be seen by modifying [`examples/example.ts line 47`](https://github.com/dgreif/ring/blob/f44c7740dd0a22d85736db6f9ab32e9735deb899/examples/example.ts#L47) to log the entire device object with `JSON.stringify(device)`.

I published [`homebridge-ring-smockle@5.3.2`](https://www.npmjs.com/package/homebridge-ring-smockle) for testing. Additional screenshots below:

| Ring app | Home app |
|---|---|
| ![IMG_1140](https://user-images.githubusercontent.com/3104489/62417314-89dedd80-b61a-11e9-8d59-13fcd9e2f63a.PNG) | ![IMG_1141](https://user-images.githubusercontent.com/3104489/62417318-8fd4be80-b61a-11e9-9fdb-e8d8ce3c6994.PNG) |