### PR TITLE
Enable or disable in-home doorbell (via API or Homebridge Switch)

### DIFF
--- a/api/ring-camera.ts
+++ b/api/ring-camera.ts
@@ -47,7 +47,7 @@ function getBatteryLevel(data: CameraData) {
   return batteryLevel
 }
 
-function getExistingDoorbellType({
+function getInHomeDoorbellType({
   settings: { chime_settings }
 }: CameraData): DoorbellType | undefined {
   if (!chime_settings || (!chime_settings.type && chime_settings.type !== 0)) {
@@ -69,7 +69,7 @@ export class RingCamera {
       this.batteryLevel !== null &&
       this.batteryLevel < 100 &&
       this.batteryLevel >= 0)
-  existingDoorbellType = getExistingDoorbellType(this.initialData)
+  inHomeDoorbellType = getInHomeDoorbellType(this.initialData)
 
   onRequestUpdate = new Subject()
   onRequestActiveDings = new Subject()
@@ -167,9 +167,9 @@ export class RingCamera {
     return true
   }
 
-  // Enable or disable the existing doorbell (if digital or mechanical)
-  async setExistingDoorbell(on: boolean) {
-    if (this.existingDoorbellType === undefined) {
+  // Enable or disable the in-home doorbell (if digital or mechanical)
+  async setInHomeDoorbell(on: boolean) {
+    if (this.inHomeDoorbellType === undefined) {
       return false
     }
 

--- a/api/ring-camera.ts
+++ b/api/ring-camera.ts
@@ -47,17 +47,13 @@ function getBatteryLevel(data: CameraData) {
   return batteryLevel
 }
 
-function getExistingDoorbellType(data: CameraData): DoorbellType | undefined {
-  if (
-    !data ||
-    !data.settings ||
-    !data.settings.chime_settings ||
-    (!data.settings.chime_settings.type &&
-      data.settings.chime_settings.type !== 0)
-  ) {
+function getExistingDoorbellType({
+  settings: { chime_settings }
+}: CameraData): DoorbellType | undefined {
+  if (!chime_settings || (!chime_settings.type && chime_settings.type !== 0)) {
     return undefined
   }
-  return data.settings.chime_settings.type
+  return chime_settings.type
 }
 
 export class RingCamera {

--- a/api/ring-camera.ts
+++ b/api/ring-camera.ts
@@ -5,7 +5,8 @@ import {
   CameraHealth,
   HistoricalDingGlobal,
   RingCameraModel,
-  SnapshotTimestamp
+  SnapshotTimestamp,
+  DoorbellType
 } from './ring-types'
 import { clientApi, RingRestClient } from './rest-client'
 import { BehaviorSubject, Subject } from 'rxjs'
@@ -66,9 +67,12 @@ export class RingCamera {
       this.batteryLevel !== null &&
       this.batteryLevel < 100 &&
       this.batteryLevel >= 0)
-  hasInHomeDoorbell =
+  hasInHomeDoorbell = Boolean(
     this.initialData.settings.chime_settings &&
-    this.initialData.settings.chime_settings.type
+      [DoorbellType.Mechanical, DoorbellType.Digital].includes(
+        this.initialData.settings.chime_settings.type
+      )
+  )
 
   onRequestUpdate = new Subject()
   onRequestActiveDings = new Subject()
@@ -172,7 +176,7 @@ export class RingCamera {
 
   // Enable or disable the in-home doorbell (if digital or mechanical)
   async setInHomeDoorbell(on: boolean) {
-    if (this.hasInHomeDoorbell === undefined) {
+    if (!this.hasInHomeDoorbell) {
       return false
     }
 

--- a/api/ring-camera.ts
+++ b/api/ring-camera.ts
@@ -47,7 +47,7 @@ function getBatteryLevel(data: CameraData) {
   return batteryLevel
 }
 
-function getInHomeDoorbellStatus(data: CameraData): boolean | undefined {
+export function getInHomeDoorbellStatus(data: CameraData): boolean | undefined {
   if (!data.settings.chime_settings) {
     return undefined
   }

--- a/api/ring-types.ts
+++ b/api/ring-types.ts
@@ -271,6 +271,12 @@ export interface TicketAsset {
   uuid: string
 }
 
+export enum DoorbellType {
+  Mechanical = 0,
+  Digital = 1,
+  None = 2
+}
+
 export interface CameraData {
   id: number
   description: string
@@ -295,26 +301,30 @@ export interface CameraData {
       zone1: any
       zone2: any
       zone3: any
-      motion_snooze_preset_profile: string
-      live_view_preset_profile: string
-      live_view_presets: string[]
-      motion_snooze_presets: string[]
-      doorbell_volume: number
-      chime_settings: any
-      video_settings: any
-      motion_announcement: boolean
-      stream_setting: number
-      advanced_motion_detection_enabled: boolean
-      advanced_motion_detection_human_only_mode: boolean
-      luma_night_threshold: number
-      enable_audio_recording: boolean | null
-      people_detection_eligible: false
-      pir_settings?: any
-      pir_motion_zones?: number[]
-      floodlight_settings?: any
-      light_schedule_settings?: any
-      luma_light_threshold?: number
     }
+    motion_snooze_preset_profile: string
+    live_view_preset_profile: string
+    live_view_presets: string[]
+    motion_snooze_presets: string[]
+    doorbell_volume: number
+    chime_settings: {
+      type: DoorbellType
+      enable: boolean
+      duration: number
+    }
+    video_settings: any
+    motion_announcement: boolean
+    stream_setting: number
+    advanced_motion_detection_enabled: boolean
+    advanced_motion_detection_human_only_mode: boolean
+    luma_night_threshold: number
+    enable_audio_recording: boolean | null
+    people_detection_eligible: false
+    pir_settings?: any
+    pir_motion_zones?: number[]
+    floodlight_settings?: any
+    light_schedule_settings?: any
+    luma_light_threshold?: number
   }
   features: {
     motions_enabled: boolean

--- a/api/ring-types.ts
+++ b/api/ring-types.ts
@@ -307,7 +307,7 @@ export interface CameraData {
     live_view_presets: string[]
     motion_snooze_presets: string[]
     doorbell_volume: number
-    chime_settings: {
+    chime_settings?: {
       type: DoorbellType
       enable: boolean
       duration: number

--- a/homebridge/README.md
+++ b/homebridge/README.md
@@ -66,6 +66,7 @@ Only include an optional parameter if you actually need it.  Default behavior wi
   "hideDoorbellSwitch": true,
   "hideCameraMotionSensor": true,
   "hideCameraSirenSwitch": true,
+  "hideExistingDoorbellSwitch": true,
   "hideAlarmSirenSwitch": true,
   "cameraStatusPollingSeconds": 20,
   "cameraDingsPollingSeconds": 2,
@@ -81,6 +82,7 @@ Option | Default | Explanation
 `hideDoorbellSwitch` | `false` | If you have a Ring video doorbell, you will see a Programmable Switch associated with it.  This switch can be used to perform actions on when the doorbell is pressed using "Single Press" actions.  If you do not care to perform actions when the doorbell is pressed, you can hide the Programmable Switch by setting this option to `true`. You will still be able to receive _notifications_ from the doorbell even if the Programmable Switch is hidden (notifications can be configured in the settings for the doorbell camera in the Home app)
 `hideCameraMotionSensor` | `false` | If `true`, hides the motion sensor for Ring cameras in HomeKit.
 `hideCameraSirenSwitch` | `false` | If `true`, hides the siren switch for Ring cameras in HomeKit.
+`hideExistingDoorbellSwitch` | `false` | If `true`, hides the switch for existing doorbells in HomeKit.
 `hideAlarmSirenSwitch` | `false` | If you have a Ring Alarm, you will see both the alarm and a "Siren" switch in HomeKit.  The siren switch can sometimes get triggered by Siri commands by accident, which is loud and annoying.  Set this option to `true` to hide the siren switch.
 `showPanicButtons` | `false` | Creates a new `Panic Buttons` device in HomeKit with `Burglar Alarm` and `Fire Alarm` switches.  **Use these at your own risk.  I do not guarantee functionality in case of emergency, nor do I take responsibility for any false alarms**.  These function just like the SOS sliders in the Ring app.
 `cameraStatusPollingSeconds` | `20` | How frequently to poll for updates to your cameras.  Information like light/siren status do not update in real time and need to be requested periodically.
@@ -106,6 +108,8 @@ Walk through the setup pages and when you are done, you should see several devic
   * Light (if camera is equipped)
   * Siren Switch (if camera is equipped)
     * Can be hidden with `hideCameraSirenSwitch`
+  * Existing Doorbell Switch (if doorbell is equipped)
+    * Can be hidden with `hideExistingDoorbellSwitch`
   * Programmable switch for doorbells (triggers `Single Press` actions)
     * Note: doorbell event notifications should be configured via settings on the camera feed
     * Can be hidden with `hideDoorbellSwitch`

--- a/homebridge/README.md
+++ b/homebridge/README.md
@@ -66,7 +66,7 @@ Only include an optional parameter if you actually need it.  Default behavior wi
   "hideDoorbellSwitch": true,
   "hideCameraMotionSensor": true,
   "hideCameraSirenSwitch": true,
-  "hideExistingDoorbellSwitch": true,
+  "hideInHomeDoorbellSwitch": true,
   "hideAlarmSirenSwitch": true,
   "cameraStatusPollingSeconds": 20,
   "cameraDingsPollingSeconds": 2,
@@ -82,7 +82,7 @@ Option | Default | Explanation
 `hideDoorbellSwitch` | `false` | If you have a Ring video doorbell, you will see a Programmable Switch associated with it.  This switch can be used to perform actions on when the doorbell is pressed using "Single Press" actions.  If you do not care to perform actions when the doorbell is pressed, you can hide the Programmable Switch by setting this option to `true`. You will still be able to receive _notifications_ from the doorbell even if the Programmable Switch is hidden (notifications can be configured in the settings for the doorbell camera in the Home app)
 `hideCameraMotionSensor` | `false` | If `true`, hides the motion sensor for Ring cameras in HomeKit.
 `hideCameraSirenSwitch` | `false` | If `true`, hides the siren switch for Ring cameras in HomeKit.
-`hideExistingDoorbellSwitch` | `false` | If `true`, hides the switch for existing doorbells in HomeKit.
+`hideInHomeDoorbellSwitch` | `false` | If `true`, hides the switch for in-home doorbells in HomeKit.
 `hideAlarmSirenSwitch` | `false` | If you have a Ring Alarm, you will see both the alarm and a "Siren" switch in HomeKit.  The siren switch can sometimes get triggered by Siri commands by accident, which is loud and annoying.  Set this option to `true` to hide the siren switch.
 `showPanicButtons` | `false` | Creates a new `Panic Buttons` device in HomeKit with `Burglar Alarm` and `Fire Alarm` switches.  **Use these at your own risk.  I do not guarantee functionality in case of emergency, nor do I take responsibility for any false alarms**.  These function just like the SOS sliders in the Ring app.
 `cameraStatusPollingSeconds` | `20` | How frequently to poll for updates to your cameras.  Information like light/siren status do not update in real time and need to be requested periodically.
@@ -108,8 +108,8 @@ Walk through the setup pages and when you are done, you should see several devic
   * Light (if camera is equipped)
   * Siren Switch (if camera is equipped)
     * Can be hidden with `hideCameraSirenSwitch`
-  * Existing Doorbell Switch (if doorbell is equipped)
-    * Can be hidden with `hideExistingDoorbellSwitch`
+  * In-Home Doorbell Switch (if doorbell is equipped)
+    * Can be hidden with `hideInHomeDoorbellSwitch`
   * Programmable switch for doorbells (triggers `Single Press` actions)
     * Note: doorbell event notifications should be configured via settings on the camera feed
     * Can be hidden with `hideDoorbellSwitch`

--- a/homebridge/camera.ts
+++ b/homebridge/camera.ts
@@ -85,6 +85,27 @@ export class Camera extends BaseAccessory<RingCamera> {
       )
     }
 
+    if (
+      device.existingDoorbellType !== undefined &&
+      !config.hideExistingDoorbellSwitch
+    ) {
+      this.registerCharacteristic(
+        Characteristic.On,
+        Service.Switch,
+        data => {
+          return Boolean(
+            data.settings &&
+              data.settings.chime_settings &&
+              data.settings.chime_settings.enable
+          )
+        },
+        value => device.setExistingDoorbell(value),
+        0,
+        device.name + ' Existing Doorbell',
+        () => device.requestUpdate()
+      )
+    }
+
     this.registerCharacteristic(
       Characteristic.Manufacturer,
       Service.AccessoryInformation,

--- a/homebridge/camera.ts
+++ b/homebridge/camera.ts
@@ -1,6 +1,6 @@
 import { HAP, hap } from './hap'
 import { RingPlatformConfig } from './config'
-import { RingCamera, DoorbellType } from '../api'
+import { RingCamera, DoorbellType, CameraData } from '../api'
 import { BaseAccessory } from './base-accessory'
 import { filter, map, mapTo } from 'rxjs/operators'
 import { CameraSource } from './camera-source'
@@ -53,6 +53,19 @@ export class Camera extends BaseAccessory<RingCamera> {
           onPressed
         )
       }
+
+      if (!config.hideInHomeDoorbellSwitch) {
+        this.registerObservableCharacteristic(
+          Characteristic.On,
+          Service.Switch,
+          device.onInHomeDoorbellStatus.pipe(
+            map(inHomeDoorbellStatus => {
+              return Boolean(inHomeDoorbellStatus)
+            })
+          ),
+          device.name + ' Existing Doorbell'
+        )
+      }
     }
 
     if (device.hasLight) {
@@ -81,26 +94,6 @@ export class Camera extends BaseAccessory<RingCamera> {
         value => device.setSiren(value),
         0,
         device.name + ' Siren',
-        () => device.requestUpdate()
-      )
-    }
-
-    if (
-      device.inHomeDoorbellType !== undefined &&
-      device.inHomeDoorbellType !== DoorbellType.None &&
-      !config.hideInHomeDoorbellSwitch
-    ) {
-      this.registerCharacteristic(
-        Characteristic.On,
-        Service.Switch,
-        data => {
-          return Boolean(
-            data.settings.chime_settings && data.settings.chime_settings.enable
-          )
-        },
-        value => device.setInHomeDoorbell(value),
-        0,
-        device.name + ' Existing Doorbell',
         () => device.requestUpdate()
       )
     }

--- a/homebridge/camera.ts
+++ b/homebridge/camera.ts
@@ -1,6 +1,6 @@
 import { HAP, hap } from './hap'
 import { RingPlatformConfig } from './config'
-import { RingCamera } from '../api'
+import { RingCamera, DoorbellType } from '../api'
 import { BaseAccessory } from './base-accessory'
 import { filter, map, mapTo } from 'rxjs/operators'
 import { CameraSource } from './camera-source'
@@ -87,6 +87,7 @@ export class Camera extends BaseAccessory<RingCamera> {
 
     if (
       device.existingDoorbellType !== undefined &&
+      device.existingDoorbellType !== DoorbellType.None &&
       !config.hideExistingDoorbellSwitch
     ) {
       this.registerCharacteristic(

--- a/homebridge/camera.ts
+++ b/homebridge/camera.ts
@@ -105,7 +105,7 @@ export class Camera extends BaseAccessory<RingCamera> {
         (value: boolean) => device.setInHomeDoorbell(value),
         0,
         device.name + ' In-Home Doorbell',
-        device.requestUpdate
+        () => device.requestUpdate()
       )
     }
 

--- a/homebridge/camera.ts
+++ b/homebridge/camera.ts
@@ -86,21 +86,19 @@ export class Camera extends BaseAccessory<RingCamera> {
     }
 
     if (
-      device.existingDoorbellType !== undefined &&
-      device.existingDoorbellType !== DoorbellType.None &&
-      !config.hideExistingDoorbellSwitch
+      device.inHomeDoorbellType !== undefined &&
+      device.inHomeDoorbellType !== DoorbellType.None &&
+      !config.hideInHomeDoorbellSwitch
     ) {
       this.registerCharacteristic(
         Characteristic.On,
         Service.Switch,
         data => {
           return Boolean(
-            data.settings &&
-              data.settings.chime_settings &&
-              data.settings.chime_settings.enable
+            data.settings.chime_settings && data.settings.chime_settings.enable
           )
         },
-        value => device.setExistingDoorbell(value),
+        value => device.setInHomeDoorbell(value),
         0,
         device.name + ' Existing Doorbell',
         () => device.requestUpdate()

--- a/homebridge/config.schema.json
+++ b/homebridge/config.schema.json
@@ -50,7 +50,7 @@
       },
       "hideInHomeDoorbellSwitch": {
         "title": "Hide In-Home Doorbell Switch",
-        "type": "booolean"
+        "type": "boolean"
       },
       "hideAlarmSirenSwitch": {
         "title": "Hide Alarm Siren Switch",

--- a/homebridge/config.schema.json
+++ b/homebridge/config.schema.json
@@ -48,8 +48,8 @@
         "title": "Hide Camera Siren Switch",
         "type": "boolean"
       },
-      "hideExistingDoorbellSwitch": {
-        "title": "Hide Existing Doorbell Switch",
+      "hideInHomeDoorbellSwitch": {
+        "title": "Hide In-Home Doorbell Switch",
         "type": "booolean"
       },
       "hideAlarmSirenSwitch": {
@@ -135,7 +135,7 @@
         "hideDoorbellSwitch",
         "hideCameraMotionSensor",
         "hideCameraSirenSwitch",
-        "hideExistingDoorbellSwitch",
+        "hideInHomeDoorbellSwitch",
         "hideAlarmSirenSwitch",
         "showPanicButtons",
         "beamDurationSeconds",

--- a/homebridge/config.schema.json
+++ b/homebridge/config.schema.json
@@ -48,6 +48,10 @@
         "title": "Hide Camera Siren Switch",
         "type": "boolean"
       },
+      "hideExistingDoorbellSwitch": {
+        "title": "Hide Existing Doorbell Switch",
+        "type": "booolean"
+      },
       "hideAlarmSirenSwitch": {
         "title": "Hide Alarm Siren Switch",
         "type": "boolean",
@@ -94,15 +98,10 @@
     },
     "oneOf": [
       {
-        "required": [
-          "email",
-          "password"
-        ]
+        "required": ["email", "password"]
       },
       {
-        "required": [
-          "refreshToken"
-        ]
+        "required": ["refreshToken"]
       }
     ]
   },
@@ -124,9 +123,7 @@
     {
       "type": "flex",
       "flex-flow": "row wrap",
-      "items": [
-        "refreshToken"
-      ]
+      "items": ["refreshToken"]
     },
     {
       "type": "fieldset",
@@ -138,6 +135,7 @@
         "hideDoorbellSwitch",
         "hideCameraMotionSensor",
         "hideCameraSirenSwitch",
+        "hideExistingDoorbellSwitch",
         "hideAlarmSirenSwitch",
         "showPanicButtons",
         "beamDurationSeconds",

--- a/homebridge/config.ts
+++ b/homebridge/config.ts
@@ -8,6 +8,7 @@ export interface RingPlatformConfig extends RingApiOptions {
   hideDoorbellSwitch?: boolean
   hideCameraMotionSensor?: boolean
   hideCameraSirenSwitch?: boolean
+  hideExistingDoorbellSwitch?: boolean
   hideAlarmSirenSwitch?: boolean
   showPanicButtons?: boolean
 }

--- a/homebridge/config.ts
+++ b/homebridge/config.ts
@@ -8,7 +8,7 @@ export interface RingPlatformConfig extends RingApiOptions {
   hideDoorbellSwitch?: boolean
   hideCameraMotionSensor?: boolean
   hideCameraSirenSwitch?: boolean
-  hideExistingDoorbellSwitch?: boolean
+  hideInHomeDoorbellSwitch?: boolean
   hideAlarmSirenSwitch?: boolean
   showPanicButtons?: boolean
 }


### PR DESCRIPTION
# Details
Toggles the “Ring my in-home doorbell” setting (screenshot below):
![Ring my in-home doorbell](https://user-images.githubusercontent.com/3104489/66874829-73d68d00-ef7a-11e9-902c-03a11e650ca7.jpeg)

# Other Implementations
`python-ring-doorbell` implements this method in [`doorbot.py#L113-L133`](https://github.com/tchellomello/python-ring-doorbell/blob/6d2368b6615368a8724502d59755d14e0aa6e6f9/ring_doorbell/doorbot.py#L113-L133)

# Testing
I published [`homebridge-ring-smockle@5.8.8`](https://www.npmjs.com/package/homebridge-ring-smockle) to help with testing.

Note: If you toggle the switch in the Home app, then check status in the Ring app, you may see an outdated status, unless you’ve navigated to the main camera settings page.

# Example Use Cases
- Mute doorbell at night
- Mute doorbell when Do Not Disturb is enabled
- Mute doorbell when nursery white noise machine is turned on