### PR TITLE
Ring Chime support

### DIFF
--- a/api/api.ts
+++ b/api/api.ts
@@ -10,9 +10,11 @@ import {
   BaseStation,
   BeamBridge,
   CameraData,
+  Chime,
   UserLocation,
 } from './ring-types'
 import { RingCamera } from './ring-camera'
+import { RingChime } from './ring-chime'
 import { EMPTY, merge, Subject } from 'rxjs'
 import { debounceTime, switchMap, throttleTime } from 'rxjs/operators'
 import { enableDebug } from './util'
@@ -83,12 +85,14 @@ export class RingApi {
   async fetchRingDevices() {
     const {
       doorbots,
+      chimes,
       authorized_doorbots: authorizedDoorbots,
       stickup_cams: stickupCams,
       base_stations: baseStations,
       beams_bridges: beamBridges,
     } = await this.restClient.request<{
       doorbots: CameraData[]
+      chimes: Chime[]
       authorized_doorbots: CameraData[]
       stickup_cams: CameraData[]
       base_stations: BaseStation[]
@@ -97,6 +101,7 @@ export class RingApi {
 
     return {
       doorbots,
+      chimes,
       authorizedDoorbots,
       stickupCams,
       allCameras: doorbots.concat(stickupCams, authorizedDoorbots),
@@ -203,6 +208,7 @@ export class RingApi {
     const rawLocations = await this.fetchRawLocations(),
       {
         authorizedDoorbots,
+        chimes,
         doorbots,
         allCameras,
         baseStations,
@@ -219,6 +225,7 @@ export class RingApi {
             this.restClient
           )
       ),
+      ringChimes = chimes.map((data) => new RingChime(data, this.restClient)),
       locations = rawLocations
         .filter((location) => {
           return (
@@ -231,6 +238,9 @@ export class RingApi {
             new Location(
               location,
               cameras.filter(
+                (x) => x.data.location_id === location.location_id
+              ),
+              ringChimes.filter(
                 (x) => x.data.location_id === location.location_id
               ),
               {

--- a/api/location.ts
+++ b/api/location.ts
@@ -39,6 +39,7 @@ import {
 } from './ring-types'
 import { appApi, clientApi, RingRestClient } from './rest-client'
 import { getSearchQueryString, RingCamera } from './ring-camera'
+import { RingChime } from './ring-chime'
 import { RingDevice } from './ring-device'
 
 const deviceListMessageType = 'DeviceInfoDocGetList'
@@ -119,6 +120,7 @@ export class Location {
   constructor(
     public readonly locationDetails: UserLocation,
     public readonly cameras: RingCamera[],
+    public readonly chimes: RingChime[],
     public readonly options: {
       hasHubs: boolean
       hasAlarmBaseStation: boolean

--- a/api/ring-chime.ts
+++ b/api/ring-chime.ts
@@ -1,0 +1,103 @@
+import {
+  Chime,
+  ChimeOptions,
+  ChimeSoundKind,
+  RingtoneOptions,
+} from './ring-types'
+import { clientApi, RingRestClient } from './rest-client'
+import { delay } from './util'
+
+export class RingChime {
+  id = this.initialData.id
+
+  constructor(private initialData: Chime, private restClient: RingRestClient) {}
+
+  get data() {
+    return this.initialData
+  }
+
+  get description() {
+    return this.initialData.description
+  }
+
+  get volume() {
+    return this.initialData.settings.volume
+  }
+
+  getRingtones() {
+    return this.restClient.request<RingtoneOptions>({
+      url: clientApi('ringtones'),
+    })
+  }
+
+  async getRingtoneByDescription(description: string, kind: ChimeSoundKind) {
+    const ringtones = await this.getRingtones(),
+      requestedRingtone = ringtones.audios.find(
+        (audio) =>
+          audio.available &&
+          audio.description === description &&
+          audio.kind === kind
+      )
+
+    if (!requestedRingtone) {
+      throw new Error('Requested ringtone not found')
+    }
+
+    return requestedRingtone
+  }
+
+  chimeUrl(path = '') {
+    return clientApi(`chimes/${this.id}/${path}`)
+  }
+
+  playSound(kind: ChimeSoundKind) {
+    return this.restClient.request({
+      url: this.chimeUrl('play_sound'),
+      method: 'POST',
+      json: true,
+      data: { kind },
+    })
+  }
+
+  snooze(time: number) {
+    return this.restClient.request({
+      url: this.chimeUrl('do_not_disturb'),
+      method: 'POST',
+      json: true,
+      data: { time },
+    })
+  }
+
+  clearSnooze() {
+    return this.restClient.request({
+      url: this.chimeUrl('do_not_disturb'),
+      method: 'POST',
+    })
+  }
+
+  async updateChime(data: ChimeOptions) {
+    await this.restClient.request({
+      url: this.chimeUrl(),
+      method: 'PUT',
+      json: true,
+      data,
+    })
+
+    const {
+      ding_audio_user_id,
+      motion_audio_id,
+      ding_audio_id,
+      motion_audio_user_id,
+    } = data.chime?.settings || {}
+
+    if (
+      ding_audio_id ||
+      ding_audio_user_id ||
+      motion_audio_id ||
+      motion_audio_user_id
+    ) {
+      // allow chime to update and restart with new ringtone (will blink blue)
+      await delay(20000)
+    }
+  }
+}

--- a/api/ring-types.ts
+++ b/api/ring-types.ts
@@ -259,6 +259,81 @@ export interface BeamBridge {
   updated_at: string
 }
 
+export interface Chime {
+  id: number
+  description: string
+  device_id: string
+  time_zone: string
+  firmware_version: Firmware
+  kind: string
+  latitude: number
+  longitude: number
+  address: string
+  settings: {
+    volume: number
+    ding_audio_user_id: string
+    ding_audio_id: string
+    motion_audio_user_id: string
+    motion_audio_id: string
+  }
+  features: {
+    ringtones_enabled: boolean
+  }
+  owned: boolean
+  alerts: {
+    connection: string
+    rssi: string
+  }
+  do_not_disturb: {
+    seconds_left: number
+  }
+  stolen: boolean
+  location_id: string
+  ring_id: null
+  owner: {
+    id: number
+    first_name: string
+    last_name: string
+    email: string
+  }
+}
+
+export type ChimeSoundKind = 'motion' | 'ding'
+
+export interface ChimeOptions {
+  chime: {
+    description?: string
+    latitude?: number
+    longitude?: number
+    address?: string
+    settings?: {
+      volume?: number
+      ding_audio_user_id?: string
+      ding_audio_id?: string
+      motion_audio_user_id?: string
+      motion_audio_id?: string
+    }
+  }
+}
+
+export interface RingtoneOptions {
+  default_ding_user_id: string
+  default_ding_id: string
+  default_motion_user_id: string
+  default_motion_id: string
+  audios: [
+    {
+      user_id: string
+      id: string
+      description: string
+      kind: string
+      url: string
+      checksum: string
+      available: string
+    }
+  ]
+}
+
 export interface LocationAddress {
   address1: string
   address2: string

--- a/examples/chime-example.ts
+++ b/examples/chime-example.ts
@@ -1,0 +1,27 @@
+import 'dotenv/config'
+import { RingApi } from '../api'
+
+async function example() {
+  const ringApi = new RingApi({
+      refreshToken: process.env.RING_REFRESH_TOKEN!,
+    }),
+    locations = await ringApi.getLocations(),
+    [myLocation] = locations,
+    [myChime] = myLocation.chimes,
+    newRingtone = await myChime.getRingtoneByDescription('Triangle', 'ding')
+
+  await myChime.updateChime({
+    chime: {
+      settings: {
+        ding_audio_id: newRingtone.id,
+        ding_audio_user_id: newRingtone.user_id,
+      },
+    },
+  })
+
+  await myChime.playSound('ding')
+
+  await myChime.playSound('motion')
+}
+
+example()


### PR DESCRIPTION
Firstly, thank you for this awesome repo @dgreif. Definitely one of the highest quality homebridge repos to date!

Hoping I can contribute here a bit for issue https://github.com/dgreif/ring/issues/262. I haven't yet worked with a speaker device type like you had mentioned in that issue, so I figured I would try to implement the Chime API side of things and then discuss the homebridge side a bit further with you.

Currently with this PR, a chime has these abilities:
- Play a motion sound
- Play a ding sound
- Set a snooze interval
- Clear a snooze interval
- Fetch available ringtones
- Update chime with new volume/ringtones

I added an example of setting a new ringtone, then the `playSound` for both dings and motion events.

It would be awesome to have the ability to trigger `playSound` by way of a HomeKit automation so other motion sensors, timers, miscellaneous events could also notify the house using the chime. Like I said, I haven't worked with a speaker type in homebridge before, so wondering if that is the best approach or if something like a momentary switch type of deal would be better to play a notification sound.

Totally game for any other ideas you have!