### PR TITLE
Customizable Chime snooze duration via Brightness setting

### DIFF
--- a/homebridge/chime.ts
+++ b/homebridge/chime.ts
@@ -5,8 +5,6 @@ import { Logging, PlatformAccessory } from 'homebridge'
 import { BaseDataAccessory } from './base-data-accessory'
 import { logInfo } from '../api/util'
 
-const minutesFor24Hours = 24 * 60
-
 export class Chime extends BaseDataAccessory<RingChime> {
   constructor(
     public readonly device: RingChime,


### PR DESCRIPTION
"Brightness" is defined as a % of a day. The only allowable values are in discrete hours (0-24).

See discussion in: https://github.com/dgreif/ring/issues/167 regarding the benefits of this approach. This implementation is working.

To install this, it requires deleting the existing Chime. I do this as follows:
```sh
cat cachedAccessories | jq 'del(.[] | select(.displayName|test("Chime")))' -c > cachedAccessories.new
mv cachedAccessories.new cachedAccessories
```

I realize that `Brightness` may not be the ideal characteristic. Maybe using degrees (e.g., for a thermostat) would be more sensible, but I'd have to think through how to best do this given that users can have their settings in deg. C or F.

Also, we could think through the best icon to use, although users can still edit the lightbulb icon to another one of their choosing.