### PR TITLE
feat(api): enable retrieve/reuse sessions (#337)

### DIFF
--- a/api/rest-client.ts
+++ b/api/rest-client.ts
@@ -99,13 +99,14 @@ export interface RefreshTokenAuth {
 
 export interface SessionOptions {
   controlCenterDisplayName?: string
+  reuseSession?: SessionResponse
 }
 
 export class RingRestClient {
   // prettier-ignore
   public refreshToken = ('refreshToken' in this.authOptions ? this.authOptions.refreshToken : undefined)
   private authPromise = this.getAuth()
-  private sessionPromise = this.getSession()
+  private sessionPromise = (this.authOptions.reuseSession ? Promise.resolve(this.authOptions.reuseSession) : this.getSession())
   public using2fa = false
   public onRefreshTokenUpdated = new ReplaySubject<{
     oldRefreshToken?: string
@@ -343,5 +344,9 @@ export class RingRestClient {
 
   getCurrentAuth() {
     return this.authPromise
+  }
+
+  getCurrentSession() {
+    return this.sessionPromise
   }
 }

--- a/api/ring-types.ts
+++ b/api/ring-types.ts
@@ -648,7 +648,11 @@ export interface SessionResponse {
     created_at: string
     tfa_enabled: boolean
     tfa_phone_number: null | string
-    [extra_meta:string] : any
+    account_type: null | string
+    user_preferences: {
+      settings: any
+      preferences: any
+    }
   }
 }
 

--- a/api/ring-types.ts
+++ b/api/ring-types.ts
@@ -636,7 +636,7 @@ export interface SessionResponse {
     email: string
     first_name: string
     last_name: string
-    phone_number: string
+    phone_number?: string | null
     authentication_token: string
     features: { [name: string]: boolean | number | string | string[] }
     hardware_id: string
@@ -648,6 +648,7 @@ export interface SessionResponse {
     created_at: string
     tfa_enabled: boolean
     tfa_phone_number: null | string
+    [extra_meta:string] : any
   }
 }
 


### PR DESCRIPTION
Allows for sessions to be retrieved and subsequently reused by the client. Ring limits session requests and this enables getting around the 406 errors that the API starts to throw.

If a single IP makes too many `/session` requests (I think the limit is maybe 50 in a 24-hour period) then you run into #337 and #247 errors. But the session response is fairly status so we can avoid the request if we know that the session is good. 