### PR TITLE
Prevent ding-loop when streaming from onNewDing

### DIFF
--- a/api/ring-camera.ts
+++ b/api/ring-camera.ts
@@ -324,10 +324,10 @@ export class RingCamera {
     const activeDings = this.activeDings,
       dingId = ding.id_str
 
-    this.onNewDing.next(ding)
     this.onActiveDings.next(
       activeDings.filter((d) => d.id_str !== dingId).concat([ding])
     )
+    this.onNewDing.next(ding)
 
     setTimeout(() => {
       this.removeDingById(ding.id_str)


### PR DESCRIPTION
Addresses issue #281 - if you call streamVideo from an onNewDing handler then the call to getSipOptions can't find the new ding in the activeDings so ends up invoking a new VOD, which in turn creates a new ding and calls processActiveDing. By swapping the order of these next() calls, a client can listen to either event and start a stream in the observer without causing the spurious VOD ding to be created.