### PR TITLE
Use Thermostat accessory to choose Snooze duration

### DIFF
--- a/homebridge/chime.ts
+++ b/homebridge/chime.ts
@@ -5,14 +5,32 @@ import { Logging, PlatformAccessory } from 'homebridge'
 import { BaseDataAccessory } from './base-data-accessory'
 import { logInfo } from '../api/util'
 
-const secondsFor1Hour = 60 * 60
-const elapsedTime = (elapsed: number) => {
+const secondsFor1Hour = 60 * 60,
+  elapsedTime = (elapsed: number) => {
     elapsed *= secondsFor1Hour
     const hours = Math.floor(elapsed / secondsFor1Hour),
-        minutes = Math.floor(elapsed / 60) % 60,
-        seconds = Math.round(elapsed % 60)
-    return `${hours}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
-}
+      minutes = Math.floor(elapsed / 60) % 60,
+      seconds = Math.round(elapsed % 60)
+    return `${hours}:${minutes
+      .toString()
+      .padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
+  }
+
+// Temperature conversion for C to F
+// Set useF based on your default HomeKit display
+//
+// Since HomeKit stores everything in Celsius, this results in some (minor) differences
+// in terms of snooze times. For example, 15:06:00 instead of 15:00:00 snooze. This could be
+// addressed differently if more accuracy is needed.
+//
+// Lastly, there are some oddities at the boundaries, so some numbers have been chosen manually
+// I.e., -17.77 or 25.5 for optimal behavior
+
+const roundSingle = (num: number) => Math.round((num + Number.EPSILON) * 10) / 10,
+  CtoF = (temp: number) => roundSingle(1.8 * temp + 32),
+  FtoC = (temp: number) =>
+    temp === 0 ? -17.77 : roundSingle((temp - 32) / 1.8),
+  useF = true
 
 export class Chime extends BaseDataAccessory<RingChime> {
   constructor(
@@ -43,78 +61,102 @@ export class Chime extends BaseDataAccessory<RingChime> {
     this.registerCharacteristic({
       characteristicType: Characteristic.CurrentHeatingCoolingState,
       serviceType: snoozeService,
-      getValue: (data) => data.do_not_disturb.seconds_left > 0 ?
-                            Characteristic.CurrentHeatingCoolingState.HEAT :
-                            Characteristic.CurrentHeatingCoolingState.OFF,
+      getValue: (data) =>
+        data.do_not_disturb.seconds_left > 0
+          ? Characteristic.TargetHeatingCoolingState.HEAT
+          : Characteristic.TargetHeatingCoolingState.OFF,
     })
     this.registerCharacteristic({
       characteristicType: Characteristic.TargetHeatingCoolingState,
       serviceType: snoozeService,
-      getValue: (data) => data.do_not_disturb.seconds_left > 0 ?
-                            Characteristic.TargetHeatingCoolingState.HEAT :
-                            Characteristic.TargetHeatingCoolingState.OFF,
+      getValue: (data) =>
+        data.do_not_disturb.seconds_left > 0
+          ? Characteristic.TargetHeatingCoolingState.HEAT
+          : Characteristic.TargetHeatingCoolingState.OFF,
       setValue: (state: number) => {
-          if (state === Characteristic.TargetHeatingCoolingState.OFF) {
-            logInfo(device.name + ' snooze cleared')
-            snoozeService
-              .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
-              .updateValue(Characteristic.CurrentHeatingCoolingState.OFF)
-            snoozeService
-              .getCharacteristic(Characteristic.TargetTemperature)
-              .updateValue(0)
-            snoozeService
-              .getCharacteristic(Characteristic.CurrentTemperature)
-              .updateValue(0)
-            return device.clearSnooze()
-          }
-       },
+        if (state === Characteristic.TargetHeatingCoolingState.OFF) {
+          logInfo(device.name + ' snooze cleared')
+          snoozeService
+            .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+            .updateValue(Characteristic.CurrentHeatingCoolingState.OFF)
+          snoozeService
+            .getCharacteristic(Characteristic.TargetTemperature)
+            .updateValue(useF ? FtoC(0) : 0)
+          snoozeService
+            .getCharacteristic(Characteristic.CurrentTemperature)
+            .updateValue(useF ? FtoC(0) : 0)
+          return device.clearSnooze()
+        }
+      },
       requestUpdate: () => device.requestUpdate(),
     })
     this.registerCharacteristic({
       characteristicType: Characteristic.CurrentTemperature,
       serviceType: snoozeService,
-      getValue: (data) => Number(Math.round((data.do_not_disturb.seconds_left / secondsFor1Hour) * 10) / 10),
+      getValue: (data) => {
+        const hours: number = data.do_not_disturb.seconds_left / secondsFor1Hour
+        return useF ? FtoC(hours) : hours
+      },
     })
     this.registerCharacteristic({
       characteristicType: Characteristic.TargetTemperature,
       serviceType: snoozeService,
-      getValue: (data) => Number(Math.round((data.do_not_disturb.seconds_left / secondsFor1Hour) * 10) / 10),
+      getValue: (data) => {
+        const hours: number = data.do_not_disturb.seconds_left / secondsFor1Hour
+        return useF ? FtoC(hours) : hours
+      },
       setValue: (snoozeHours: number) => {
+        snoozeHours = useF ? CtoF(snoozeHours) : snoozeHours
+        if (snoozeHours > 24) {
+          snoozeHours = 24 // limit per Ring API
+        }
+
         if (snoozeHours > 0) {
           logInfo(`${device.name} snoozed for ${elapsedTime(snoozeHours)}`)
           snoozeService
             .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
             .updateValue(Characteristic.CurrentHeatingCoolingState.HEAT)
+          snoozeService
             .getCharacteristic(Characteristic.TargetHeatingCoolingState)
             .updateValue(Characteristic.TargetHeatingCoolingState.HEAT)
 
           return device.snooze(Math.round(snoozeHours * 60)) // in minutes
         }
 
-        snoozeService
-          .setCharacteristic(Characteristic.TargetHeatingCoolingState, Characteristic.TargetHeatingCoolingState.OFF)
+        snoozeService.setCharacteristic(
+          Characteristic.TargetHeatingCoolingState,
+          Characteristic.TargetHeatingCoolingState.OFF
+        )
       },
       requestUpdate: () => device.requestUpdate(),
+    })
+    this.registerCharacteristic({
+      characteristicType: Characteristic.TemperatureDisplayUnits,
+      serviceType: snoozeService,
+      getValue: () => Characteristic.TemperatureDisplayUnits.CELSIUS,
     })
 
     this.getService(snoozeService)
       .getCharacteristic(Characteristic.TargetHeatingCoolingState)
       .setProps({
-          validValues: [Characteristic.TargetHeatingCoolingState.OFF, Characteristic.TargetHeatingCoolingState.HEAT]
+        validValues: [
+          Characteristic.TargetHeatingCoolingState.OFF,
+          Characteristic.TargetHeatingCoolingState.HEAT,
+        ],
       })
     this.getService(snoozeService)
       .getCharacteristic(Characteristic.CurrentTemperature)
       .setProps({
-        minValue: 0.0,
-        maxValue: 24.0,
-        minStep: 0.1
+        minValue: useF ? FtoC(0) : 0,
+        maxValue: useF ? FtoC(25.5) : 24,
+        minStep: 0.1,
       })
     this.getService(snoozeService)
       .getCharacteristic(Characteristic.TargetTemperature)
       .setProps({
-        minValue: 0.0,
-        maxValue: 24.0,
-        minStep: 0.1
+        minValue: useF ? FtoC(0) : 0,
+        maxValue: useF ? FtoC(25.5) : 24,
+        minStep: 0.1,
       })
     snoozeService.setPrimaryService(true)
 

--- a/homebridge/chime.ts
+++ b/homebridge/chime.ts
@@ -44,8 +44,8 @@ export class Chime extends BaseDataAccessory<RingChime> {
       characteristicType: Characteristic.CurrentHeatingCoolingState,
       serviceType: snoozeService,
       getValue: (data) => data.do_not_disturb.seconds_left > 0 ?
-                            Characteristic.TargetHeatingCoolingState.HEAT :
-                            Characteristic.TargetHeatingCoolingState.OFF,
+                            Characteristic.CurrentHeatingCoolingState.HEAT :
+                            Characteristic.CurrentHeatingCoolingState.OFF,
     })
     this.registerCharacteristic({
       characteristicType: Characteristic.TargetHeatingCoolingState,
@@ -58,7 +58,7 @@ export class Chime extends BaseDataAccessory<RingChime> {
             logInfo(device.name + ' snooze cleared')
             snoozeService
               .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
-              .updateValue(Characteristic.TargetHeatingCoolingState.OFF)
+              .updateValue(Characteristic.CurrentHeatingCoolingState.OFF)
             snoozeService
               .getCharacteristic(Characteristic.TargetTemperature)
               .updateValue(0)
@@ -84,6 +84,8 @@ export class Chime extends BaseDataAccessory<RingChime> {
           logInfo(`${device.name} snoozed for ${elapsedTime(snoozeHours)}`)
           snoozeService
             .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+            .updateValue(Characteristic.CurrentHeatingCoolingState.HEAT)
+            .getCharacteristic(Characteristic.TargetHeatingCoolingState)
             .updateValue(Characteristic.TargetHeatingCoolingState.HEAT)
 
           return device.snooze(Math.round(snoozeHours * 60)) // in minutes


### PR DESCRIPTION
- An improved variant of https://github.com/dgreif/ring/pull/365 OR https://github.com/dgreif/ring/pull/370
- Allows to set snooze hours in terms of degrees
- Simple toggle on/off button
- Working, but needs additional testing

### TODO: 
- Temperature units need to be converted to a normal standard (ideally celsius). I have tried setting `TemperatureDisplayUnits` but it didn't work so far.

https://github.com/homebridge/HAP-NodeJS/blob/5cacbd400bc15785f372eefb83bc40a5e21a439a/src/lib/gen/HomeKit.ts#L2953-L2975

- Might benefit from having the target temperature decoupled from the snooze duration.
- Config option to turn on/off as switch

<img width="250" src="https://user-images.githubusercontent.com/7200365/87231367-476e6680-c37c-11ea-89b0-e28dad24f3b0.png">
