### PR TITLE
feat(homebridge): support tilt sensor

### DIFF
--- a/api/ring-types.ts
+++ b/api/ring-types.ts
@@ -10,6 +10,7 @@ export enum RingDeviceType {
   FreezeSensor = 'sensor.freeze',
   TemperatureSensor = 'sensor.temperature',
   WaterSensor = 'sensor.water',
+  TiltSensor = 'sensor.tilt',
   RangeExtender = 'range-extender.zwave',
   ZigbeeAdapter = 'adapter.zigbee',
   AccessCodeVault = 'access-code.vault',

--- a/homebridge/ring-platform.ts
+++ b/homebridge/ring-platform.ts
@@ -66,6 +66,7 @@ function getAccessoryClass(
   switch (deviceType) {
     case RingDeviceType.ContactSensor:
     case RingDeviceType.RetrofitZone:
+    case RingDeviceType.TiltSensor:
       return ContactSensor
     case RingDeviceType.MotionSensor:
       return MotionSensor


### PR DESCRIPTION
Adds support for the Tilt Sensor that can be purchased in the ring shop:
https://shop.ring.com/products/ecolink-tilt-sensor-zwave2-5-eco

Will display as a Contact Sensor by default in the Home app, but can be switched via the 'Display As' to Garage Door and it works as expected then.