### PR TITLE
Allow cameras to trigger apple tv video notifications when motion is detected

### DIFF
--- a/api/ring-camera.ts
+++ b/api/ring-camera.ts
@@ -127,6 +127,11 @@ export class RingCamera extends Subscribed {
     filter((ding) => ding.kind === 'ding'),
     share()
   )
+  onMotionStart = this.onNewDing.pipe(
+    // allow new motion alerts to trigger one-off events
+    filter((ding) => ding.kind === 'motion'),
+    share()
+  )
   onMotionDetected = this.onActiveDings.pipe(
     map((dings) => dings.some((ding) => ding.motion || ding.kind === 'motion')),
     distinctUntilChanged(),

--- a/homebridge/README.md
+++ b/homebridge/README.md
@@ -58,6 +58,7 @@ Only include an optional parameter if you actually need it.  Default behavior wi
   "hideLightGroups": true,
   "hideDoorbellSwitch": true,
   "hideCameraMotionSensor": true,
+  "sendCameraMotionNotificationsToTV": false,
   "hideCameraSirenSwitch": true,
   "hideInHomeDoorbellSwitch": true,
   "hideAlarmSirenSwitch": true,
@@ -77,6 +78,7 @@ Option | Default | Explanation
 `hideLightGroups` | `false` | Ring smart lighting allows you to create lighting groups within the Ring app. These groups are convenient for detecting motion in an area of your yard and turning on/off all lights in the group.  However, you may wish to group the lights differently in HomeKit and ignore the groups you have configured in Ring.  If this option is `true`, your Ring groups (and their associated motion sensor) will be ignored and will not show up in HomeKit.
 `hideDoorbellSwitch` | `false` | If you have a Ring video doorbell, you will see a Programmable Switch associated with it.  This switch can be used to perform actions on when the doorbell is pressed using "Single Press" actions.  If you do not care to perform actions when the doorbell is pressed, you can hide the Programmable Switch by setting this option to `true`. You will still be able to receive _notifications_ from the doorbell even if the Programmable Switch is hidden (notifications can be configured in the settings for the doorbell camera in the Home app)
 `hideCameraMotionSensor` | `false` | If `true`, hides the motion sensor for Ring cameras in HomeKit.
+`sendCameraMotionNotificationsToTV` | `false` | If `true`, creates a 'Doorbell' accessory triggered by camera motion alerts for tvOS 14 notification support.
 `hideCameraSirenSwitch` | `false` | If `true`, hides the siren switch for Ring cameras in HomeKit.
 `hideInHomeDoorbellSwitch` | `false` | If `true`, hides the switch for in-home doorbells in HomeKit.
 `hideAlarmSirenSwitch` | `false` | If you have a Ring Alarm, you will see both the alarm and a "Siren" switch in HomeKit.  The siren switch can sometimes get triggered by Siri commands by accident, which is loud and annoying.  Set this option to `true` to hide the siren switch.
@@ -98,6 +100,7 @@ Option | Default | Explanation
     * Shows a live feed from the camera if you click on it.  The feed supports video and 2-way audio, but requires that you have `ffmpeg` with `libfdk_aac` installed.  A pre-built `ffmpeg` will be automatically installed on most platforms using `ffmpeg-for-homebridge`.  See the [FFmpeg wiki](https://github.com/dgreif/ring/wiki/FFmpeg) for details.
   * Motion Sensor
     * Can be hidden with `hideCameraMotionSensor`
+    * Can be shown as a doorbell with `sendCameraMotionNotificationsToTV` for tvOS 14 notifications 
   * Light (if camera is equipped)
   * Siren Switch (if camera is equipped)
     * Can be hidden with `hideCameraSirenSwitch`

--- a/homebridge/config.schema.json
+++ b/homebridge/config.schema.json
@@ -31,6 +31,10 @@
         "title": "Hide Camera Motion Sensors",
         "type": "boolean"
       },
+      "sendCameraMotionNotificationsToTV": {
+        "title": "Show Camera New Motion Alerts as a Doorbell accessory press. This allows cameras to trigger automatic tvOS 14+ notifications and PiP video to appear when motion is detected.",
+        "type": "boolean"
+      },
       "hideCameraSirenSwitch": {
         "title": "Hide Camera Siren Switch",
         "type": "boolean"

--- a/homebridge/config.ts
+++ b/homebridge/config.ts
@@ -7,6 +7,7 @@ export interface RingPlatformConfig extends RingApiOptions {
   hideLightGroups?: boolean
   hideDoorbellSwitch?: boolean
   hideCameraMotionSensor?: boolean
+  sendCameraMotionNotificationsToTV?: boolean
   hideCameraSirenSwitch?: boolean
   hideInHomeDoorbellSwitch?: boolean
   hideAlarmSirenSwitch?: boolean


### PR DESCRIPTION
Added config option to let a standard (non-doorbell) camera create a doorbell accessory that simulates a doorbell press when they detect motion. Defaults off.

AppleTV notifications only support doorbell accessories right now, so this lets you to make any camera automatically open a live picture-in-picture thumbnail video on-screen when it detects motion. You can turn individual camera alerts on/off on a device in homekit settings.

The existing onMotionDetected seems to need to generate a motion alert whenever homebridge is restarted which made it annoying and wasn't very reliable for doorbell-style triggers - but adding an onMotionStart that worked similar to onDoorbellPressed seems to work really well, but theres probably a much better way of doing that I'm missing though?