### PR TITLE
Enable faster start of stream

### DIFF
--- a/api/sip-session.ts
+++ b/api/sip-session.ts
@@ -138,6 +138,8 @@ export class SipSession extends Subscribed {
         'pipe,udp,rtp,file,crypto',
         '-f',
         'sdp',
+        '-probesize', '32',
+        '-analyzeduration', '1000',
         ...(ffmpegOptions.input || []),
         '-i',
         'pipe:',
@@ -175,6 +177,7 @@ export class SipSession extends Subscribed {
       inputSdpLines.push(
         `m=video ${videoPort} RTP/SAVP 99`,
         'a=rtpmap:99 H264/90000',
+        'a=framesize:99 1920-1080',
         createCryptoLine(remoteRtpOptions.video),
         'a=rtcp-mux'
       )

--- a/api/sip-session.ts
+++ b/api/sip-session.ts
@@ -140,6 +140,7 @@ export class SipSession extends Subscribed {
         'sdp',
         '-probesize', '32',
         '-analyzeduration', '1000',
+        '-r', '15',
         ...(ffmpegOptions.input || []),
         '-i',
         'pipe:',


### PR DESCRIPTION
ffmpeg spends about 3 seconds analyzing the RTP stream to determine the details of the streamed video. This change instructs the RTP decoder to use a fixed frame size, and ffmpeg to spend nearly no time analyzing the incoming stream. If the native frame size of the camera doesn't match this then it has no adverse effects that I can observe. I find this allows streaming to start in less than 1 second.

cc @dgreif 