### PR TITLE
Add support for outlets

### DIFF
--- a/homebridge/outlet.ts
+++ b/homebridge/outlet.ts
@@ -1,0 +1,37 @@
+import { BaseDeviceAccessory } from './base-device-accessory'
+import { RingDevice } from '../api'
+import { hap } from './hap'
+import { RingPlatformConfig } from './config'
+import { Logging, PlatformAccessory } from 'homebridge'
+
+export class Outlet extends BaseDeviceAccessory {
+  constructor(
+    public readonly device: RingDevice,
+    public readonly accessory: PlatformAccessory,
+    public readonly logger: Logging,
+    public readonly config: RingPlatformConfig
+  ) {
+    super()
+
+    const { Characteristic, Service } = hap
+
+    this.registerCharacteristic({
+      characteristicType: Characteristic.On,
+      serviceType: Service.Outlet,
+      getValue: (data) => Boolean(data.on),
+      setValue: (value) => this.setOnState(value),
+    })
+
+    this.registerCharacteristic({
+      characteristicType: Characteristic.OutletInUse,
+      serviceType: Service.Outlet,
+      getValue: (data) => Boolean(data.on),
+    })
+  }
+
+  setOnState(on: boolean) {
+    this.logger.info(`Turning ${this.device.name} ${on ? 'On' : 'Off'}`)
+
+    return this.device.setInfo({ device: { v1: { on } } })
+  }
+}

--- a/homebridge/ring-platform.ts
+++ b/homebridge/ring-platform.ts
@@ -29,6 +29,7 @@ import { RingPlatformConfig, updateHomebridgeConfig } from './config'
 import { Beam } from './beam'
 import { MultiLevelSwitch } from './multi-level-switch'
 import { Fan } from './fan'
+import { Outlet } from './outlet'
 import { Switch } from './switch'
 import { Camera } from './camera'
 import { PanicButtons } from './panic-buttons'
@@ -99,7 +100,10 @@ function getAccessoryClass(
     case RingDeviceType.MultiLevelBulb:
       return MultiLevelSwitch
     case RingDeviceType.Switch:
-      return Switch
+      return device instanceof RingDevice &&
+        device.categoryId === RingDeviceCategory.Outlets
+        ? Outlet
+        : Switch
     case RingDeviceType.TemperatureSensor:
       return TemperatureSensor
     case RingDeviceType.WaterSensor:


### PR DESCRIPTION
I recently installed a [GE/Jasco Z-Wave In-Wall Tamper-Resistant Smart Outlet (14288)](https://byjasco.com/products/ge-z-wave-plus-wall-tamper-resistant-smart-outlet). It is currently identified as a [Switch](https://developers.homebridge.io/#/service/Switch), but Homebridge supports a distinct [Outlet](https://developers.homebridge.io/#/service/Outlet) Service.

Here is the relevant output from `npm run device-data-cli` (specifically, note [`"deviceType": "switch"`](https://github.com/dgreif/ring/blob/d436ca263b3bc556768fc894d3cda3578fc90881/api/ring-types.ts#L25) and [`"categoryId": 1`](https://github.com/dgreif/ring/blob/d436ca263b3bc556768fc894d3cda3578fc90881/api/ring-types.ts#L38)):

```json
{
  "adapterType": "zwave",
  "batteryStatus": "none",
  "categoryId": 1,
  "commStatus": "ok",
  "commandTypes": {
    "communication-poll": { "requiresTrust": false },
    "reconfigure.start": { "requiresTrust": false },
    "update-node-neighbors.start": { "requiresTrust": false }
  },
  "deviceFoundTime": 1605269949114,
  "deviceType": "switch",
  "lastCommTime": 1605269948801,
  "lastUpdate": 1605269949502,
  "linkQuality": "ok",
  "managerId": "zwave",
  "name": "Dining Room Outlet",
  "pollInterval": 0,
  "roomId": 11,
  "setupByPluginStatus": "complete",
  "setupByUserStatus": "complete",
  "subCategoryId": 0,
  "tags": [],
  "tamperStatus": "ok",
  "zid": "00000000-0000-uuid",
  "on": false
},
```

The [Homebridge developer documentation for `Service.Outlet`](https://developers.homebridge.io/#/service/Outlet) lists two required Characteristics: [`On`](https://developers.homebridge.io/#/characteristic/On) and [`OutletInUse`](https://developers.homebridge.io/#/characteristic/OutletInUse).

I started with the [`Switch`](https://github.com/dgreif/ring/blob/01ac0ec4d787ef70311e58d43aca0cb84f0fe134/homebridge/switch.ts#L7) accessory as a base, then added the `OutletInUse` Characteristic. The device data from the Ring API didn’t include power draw (and the GE 14288 doesn’t support energy monitoring), so I matched the value of `OutletInUse` to that of `On`.

Then, as in #94, I added branching logic to [`getAccessoryClass` in `ring-platform.ts`](https://github.com/dgreif/ring/blob/51fdbd9ac4f016c349292d85fa1eadb6ca8bbf2f/homebridge/ring-platform.ts#L102-L106), using `deviceType` and `categoryId` to distinguish `Outlet` devices from `Switch` devices.

Finally, I tested with `npm run test-homebridge`. Both `Switch` and `Outlet` devices were added and could be controlled successfully.
