### PR TITLE
Flush DNS cache after `EHOSTUNREACH`

### DIFF
--- a/api/rest-client.ts
+++ b/api/rest-client.ts
@@ -75,7 +75,8 @@ async function requestWithRetry<T>(
       if (
         e.code === 'ENOTFOUND' ||
         e.code === 'EREFUSED' ||
-        e.code === 'ENETUNREACH'
+        e.code === 'ENETUNREACH' ||
+        e.code === 'EHOSTUNREACH'
       ) {
         const url = parseUrl(requestOptions.url)
         logDebug(


### PR DESCRIPTION
Similar to `ENOTFOUND`, `EREFUSED`, and `ENETUNREACH`, flush the DNS cache after an `EHOSTUNREACH` error. This prevents the unrecoverable (until Homebridge is restarted) state I described [on Discord](https://discord.com/channels/432663330281226270/432671438156070931/794375306235346994).

@dgreif [pointed out](https://discord.com/channels/432663330281226270/432671438156070931/795295041211465728) this is similar to #374, and suggested the fix implemented in this PR:

> [I]t might have something to do with the network interface not being initialized yet if your daemon starts too early in the boot process.  Then DNS caching could possibly cache the wrong info and stay permanently broken.  I've put in workarounds for a number of these issues, but not EHOSTUNREACH specifically.  See https://github.com/dgreif/ring/blob/master/api/rest-client.ts#L75-L91.

To verify this change, I added this condition to the compiled file located at `/usr/local/lib/node_modules/homebridge-ring/lib/api/rest-client.js`, rebooted my Mac mini, and noted (by reviewing the log file) the plugin successfully recovered from the `EHOSTUNREACH` error, once the network interface became available.