### PR TITLE
Show charging status for battery doorbells

### DIFF
--- a/api/ring-camera.ts
+++ b/api/ring-camera.ts
@@ -118,6 +118,7 @@ export class RingCamera extends Subscribed {
       this.batteryLevel !== null &&
       this.batteryLevel < 100 &&
       this.batteryLevel >= 0)
+  isCharging = this.initialData.external_connection
 
   onRequestUpdate = new Subject()
   onRequestActiveDings = new Subject()

--- a/homebridge/camera.ts
+++ b/homebridge/camera.ts
@@ -27,7 +27,7 @@ export class Camera extends BaseDataAccessory<RingCamera> {
     }
 
     const { Characteristic, Service } = hap,
-      { StatusLowBattery } = Characteristic
+      { ChargingState, StatusLowBattery } = Characteristic
 
     accessory.configureController(this.cameraSource.controller)
 
@@ -179,7 +179,7 @@ export class Camera extends BaseDataAccessory<RingCamera> {
 
     if (
       device.hasBattery ||
-      (device.batteryLevel !== null && device.batteryLevel < 100) ||
+      (device.batteryLevel !== null && device.batteryLevel <= 100) ||
       accessory.getService(Service.BatteryService)
     ) {
       this.registerCharacteristic({
@@ -189,6 +189,16 @@ export class Camera extends BaseDataAccessory<RingCamera> {
           return device.hasLowBattery
             ? StatusLowBattery.BATTERY_LEVEL_LOW
             : StatusLowBattery.BATTERY_LEVEL_NORMAL
+        },
+      })
+
+      this.registerCharacteristic({
+        characteristicType: Characteristic.ChargingState,
+        serviceType: Service.BatteryService,
+        getValue: () => {
+          return device.isCharging
+            ? ChargingState.CHARGING
+            : ChargingState.NOT_CHARGING
         },
       })
 


### PR DESCRIPTION
This adds support for showing whether battery powered doorbells are hardwired by using the charging status. I tested this by disconnecting my doorbells from the wiring, and it works as expected there.

I only have access to two different models of battery doorbell, but I don't see any reason why this should cause issues with any other device types.