### PR TITLE
feat: Support configuration to override device categories

### DIFF
--- a/homebridge/README.md
+++ b/homebridge/README.md
@@ -68,7 +68,8 @@ Only include an optional parameter if you actually need it.  Default behavior wi
   "cameraStatusPollingSeconds": 20,
   "cameraDingsPollingSeconds": 2,
   "locationModePollingSeconds": 20,
-  "locationIds": ["488e4800-fcde-4493-969b-d1a06f683102", "4bbed7a7-06df-4f18-b3af-291c89854d60"]
+  "locationIds": ["488e4800-fcde-4493-969b-d1a06f683102", "4bbed7a7-06df-4f18-b3af-291c89854d60"],
+  "categoryIdOverrides": { "f259b31c-826c-4b42-92f5-699927cbe032": 2 }
 }
 ```
 
@@ -94,6 +95,7 @@ Option | Default | Explanation
 `locationModePollingSeconds` | `20` | How frequently to poll for location mode updates (in seconds).  This is only useful if you are using location modes to control camera settings and want to keep an up-to-date reference of the current mode for each location.  Polling is automatically disabled for locations equipped with a Ring Alarm.  Will hide Location Mode switch if set to `0`
 `locationIds` | All Locations | Use this option if you only want a subset of your locations to appear in HomeKit. If this option is not included, all of your locations will be added to HomeKit (which is what most users will want to do).
 `onlyDeviceTypes` | All Device Types | A subset of device types to be shown.  If set, all other device types will be hidden in HomeKit.
+`categoryIdOverrides` | `{}` | A map of device identifiers to [device categories](https://github.com/dgreif/ring/blob/154f8fa817b7287fae28ced3c976c0de2fc31eae/api/ring-types.ts#L44-L62), used to override the device category reported by the Ring API.
 `ffmpegPath` | Uses `ffmpeg-for-homebridge` | A custom path to the `ffmpeg` executable.  By default, the static binaries built in [ffmpeg-for-homebridge](https://github.com/oznu/ffmpeg-for-homebridge) will be used.  If you prefer to use your own version of ffmpeg, you can pass a complete path, or simply `"ffmpeg"` to use ffmpeg from your `PATH`.
 `debug` | false | Turns on additional logging.  In particular, ffmpeg logging.
 

--- a/homebridge/ring-platform.ts
+++ b/homebridge/ring-platform.ts
@@ -218,6 +218,12 @@ export class RingPlatform implements DynamicPlatformPlugin {
           ),
           debugPrefix = debug ? 'TEST ' : '',
           hapDevices = allDevices.map((device) => {
+            if (device instanceof RingDevice) {
+              device.categoryId =
+                config.categoryIdOverrides[
+                  hap.uuid.generate(debugPrefix + device.id)
+                ] ?? device.categoryId
+            }
             const isCamera = device instanceof RingCamera,
               cameraIdDifferentiator = isCamera ? 'camera' : '', // this forces bridged cameras from old version of the plugin to be seen as "stale"
               AccessoryClass = (device instanceof RingCamera


### PR DESCRIPTION
A possible solution to https://github.com/dgreif/ring/issues/624 and https://github.com/dgreif/ring/issues/322.

This PR adds support for a `categoryIdOverrides` configuration option, a map between device UUIDs and [category ids](https://github.com/dgreif/ring/blob/154f8fa817b7287fae28ced3c976c0de2fc31eae/api/ring-types.ts#L44-L62).

#### Warnings
⚠️ There are currently no guardrails—devices can be associated with unrecognized or invalid categories. For example, there’s nothing stopping someone from setting the `categoryId` of their light to `11` (thermostat), though the plugin wouldn’t facilitate setting that light to 5ºC, because accessory class is primarily [determined with `deviceType`](https://github.com/dgreif/ring/blob/154f8fa817b7287fae28ced3c976c0de2fc31eae/homebridge/ring-platform.ts#L125-L126), not `categoryId`.

⚠️ I have not run this locally yet (i.e. this code is untested), because I’m not convinced this PR is worth merging (ref the “Alternative”s below)—mostly opening it for discussion.

#### Alternative — No Manual Configuration
From @dgreif in https://github.com/dgreif/ring/issues/624#issuecomment-826484908:
> Ring reports the plugins as a `switch.beams`, which simply indicates that it is a switch in their "Beams" aka Smart Lighting lineup.

I don’t have any of these devices—does anyone know if Ring reports category ids for them? If so, we could add a `categoryId`-based conditional within the [`RingDeviceType.Beams*` case](https://github.com/dgreif/ring/blob/154f8fa817b7287fae28ced3c976c0de2fc31eae/homebridge/ring-platform.ts#L103-L108) of `getAccessoryClass`, like the ternaries in [`RingDeviceType.Switch`](https://github.com/dgreif/ring/blob/154f8fa817b7287fae28ced3c976c0de2fc31eae/homebridge/ring-platform.ts#L116-L120) and [`RingDeviceType.MultilevelSwitch`](https://github.com/dgreif/ring/blob/154f8fa817b7287fae28ced3c976c0de2fc31eae/homebridge/ring-platform.ts#L109-L113), and avoid the need for any manual configuration (i.e. I would recommend _not_ merging this PR if that’s the case).

#### Alternative — Group Configuration By Category
An alternative configuration schema I considered (i.e. besides a top-level `categoryIdOverrides` key) would require breaking plugin configuration changes, but may simplify configuration overall: Group related configuration options by category (example below):

```js
// In other words, this:
{
 "hideCameraMotionSensor": true,
 "sendCameraMotionNotificationsToTv": true,
 "hideCameraSirenSwitch": true,
 "cameraStatusPollingSeconds": 20,
 "cameraDingsPollingSeconds": 2,
 "categoryIdOverrides": { "f259b31c-826c-4b42-92f5-699927cbe032": 12 } // 12 is the category id for cameras
}

// —would be replaced by this:
{
  "camera": {
    "hideMotionSensor": true,
    "sendMotionNotificationsToTv": true,
    "hideSirenSwitch": true,
    "statusPollingSeconds": 20,
    "dingsPollingSeconds": 2,
    "overrides": ["f259b31c-826c-4b42-92f5-699927cbe032"]
  }
}
```