### PR TITLE
Prevent login attempt for null refresh tokens

### DIFF
--- a/homebridge/ring-platform.ts
+++ b/homebridge/ring-platform.ts
@@ -175,7 +175,7 @@ export class RingPlatform implements DynamicPlatformPlugin {
 
     this.api.on('didFinishLaunching', () => {
       this.log.debug('didFinishLaunching')
-      if (config.refreshToken && config.refreshToken !== '') {
+      if (config.refreshToken) {
         this.connectToApi().catch((e) => {
           this.log.error('Error connecting to API')
           this.log.error(e)


### PR DESCRIPTION
I made 2 simple changes;

1. Added an if statement that only runs connectToApi() if the refreshToken is not false.
2. Changed Promise.all to Promise.allSettled. Little known function about Promise.all is it is only called if everything is resolved. If anything fails, it will hang forever. Changing this to Promise.allSettled will run even if some promises fail.

I think this is what is causing the network on raspberry pis to hang. I have tested this on armhf, arm64 and amd64 architectures.