### PR TITLE
clear timeouts when RingApi.disconnect() is called

### DIFF
--- a/api/api.ts
+++ b/api/api.ts
@@ -310,5 +310,7 @@ export class RingApi extends Subscribed {
       .catch((e) => {
         logError(e)
       })
+
+    this.restClient.clearTimeouts()
   }
 }


### PR DESCRIPTION
Fixes #850 by clearing timeouts set to refresh auth token when RingApi.disconnect() is called.