### PR TITLE
Updates to fix modern compilerOptions targets.

### DIFF
--- a/api/api.ts
+++ b/api/api.ts
@@ -17,7 +17,7 @@ import {
 } from './ring-types'
 import { RingCamera } from './ring-camera'
 import { RingChime } from './ring-chime'
-import { EMPTY, merge, Subject } from 'rxjs'
+import { EMPTY, merge, Observable, Subject } from 'rxjs'
 import { debounceTime, switchMap, throttleTime } from 'rxjs/operators'
 import { enableDebug, logError } from './util'
 import { setFfmpegPath } from './ffmpeg'
@@ -39,12 +39,17 @@ export interface RingApiOptions extends SessionOptions {
 }
 
 export class RingApi extends Subscribed {
-  public readonly restClient = new RingRestClient(this.options)
-  public readonly onRefreshTokenUpdated =
-    this.restClient.onRefreshTokenUpdated.asObservable()
+  public readonly restClient: RingRestClient
+  public readonly onRefreshTokenUpdated: Observable<{
+    oldRefreshToken?: string | undefined;
+    newRefreshToken: string;
+  }>
 
   constructor(public readonly options: RingApiOptions & RefreshTokenAuth) {
     super()
+
+    this.restClient = new RingRestClient(this.options)
+    this.onRefreshTokenUpdated = this.restClient.onRefreshTokenUpdated.asObservable()
 
     if (options.debug) {
       enableDebug()

--- a/api/location.ts
+++ b/api/location.ts
@@ -124,8 +124,8 @@ export class Location extends Subscribed {
   assets?: TicketAsset[]
   receivedAssetDeviceLists: string[] = []
   offlineAssets: string[] = []
-  hasHubs = this.options.hasHubs
-  hasAlarmBaseStation = this.options.hasAlarmBaseStation
+  hasHubs: boolean
+  hasAlarmBaseStation: boolean
 
   constructor(
     public readonly locationDetails: UserLocation,
@@ -139,6 +139,9 @@ export class Location extends Subscribed {
     private restClient: RingRestClient
   ) {
     super()
+
+    this.hasHubs = this.options.hasHubs
+    this.hasAlarmBaseStation = this.options.hasAlarmBaseStation
 
     this.addSubscriptions(
       // start listening for devices immediately

--- a/api/rest-client.ts
+++ b/api/rest-client.ts
@@ -101,8 +101,8 @@ export interface SessionOptions {
 
 export class RingRestClient {
   // prettier-ignore
-  public refreshToken = ('refreshToken' in this.authOptions ? this.authOptions.refreshToken : undefined)
-  private hardwareIdPromise = getHardwareId(this.authOptions.systemId)
+  public refreshToken: string | undefined
+  private hardwareIdPromise: Promise<string>
   private _authPromise: Promise<AuthTokenResponse> | undefined
   private timeouts: ReturnType<typeof setTimeout>[] = []
   private clearPreviousAuth() {
@@ -140,7 +140,10 @@ export class RingRestClient {
 
   constructor(
     private authOptions: (EmailAuth | RefreshTokenAuth) & SessionOptions
-  ) {}
+  ) {
+    this.refreshToken = ('refreshToken' in this.authOptions ? this.authOptions.refreshToken : undefined)
+    this.hardwareIdPromise = getHardwareId(this.authOptions.systemId)
+  }
 
   private getGrantData(twoFactorAuthCode?: string) {
     if (this.refreshToken && !twoFactorAuthCode) {

--- a/api/ring-chime.ts
+++ b/api/ring-chime.ts
@@ -5,6 +5,7 @@ import {
   RingtoneOptions,
   ChimeHealth,
   ChimeModel,
+  ChimeKind,
 } from './ring-types'
 import { clientApi, RingRestClient } from './rest-client'
 import { BehaviorSubject, Subject } from 'rxjs'
@@ -17,16 +18,21 @@ const settingsWhichRequireReboot = [
 ]
 
 export class RingChime {
-  id = this.initialData.id
-  deviceType = this.initialData.kind
-  model = ChimeModel[this.deviceType] || 'Chime'
-  onData = new BehaviorSubject<ChimeData>(this.initialData)
+  id: number
+  deviceType: ChimeKind
+  model: string
+  onData: BehaviorSubject<ChimeData>
   onRequestUpdate = new Subject()
 
   constructor(
     private initialData: ChimeData,
     private restClient: RingRestClient
-  ) {}
+  ) {
+    this.id = this.initialData.id
+    this.deviceType = this.initialData.kind
+    this.model = ChimeModel[this.deviceType] || 'Chime'
+    this.onData = new BehaviorSubject<ChimeData>(this.initialData)
+  }
 
   updateData(update: ChimeData) {
     this.onData.next(update)

--- a/api/ring-device.ts
+++ b/api/ring-device.ts
@@ -1,19 +1,18 @@
-import { BehaviorSubject } from 'rxjs'
+import { BehaviorSubject, Observable } from 'rxjs'
 import { deviceTypesWithVolume, RingDeviceData } from './ring-types'
 import { filter, map } from 'rxjs/operators'
 import { Location } from './location'
 import { Subscribed } from './subscribed'
 import { logError } from './util'
+import { RingDeviceType } from '.'
 
 export class RingDevice extends Subscribed {
-  onData = new BehaviorSubject(this.initialData)
-  zid = this.initialData.zid
-  id = this.zid
-  deviceType = this.initialData.deviceType
-  categoryId = this.initialData.categoryId
-  onComponentDevices = this.location.onDevices.pipe(
-    map((devices) => devices.filter(({ data }) => data.parentZid === this.id))
-  )
+  onData: BehaviorSubject<RingDeviceData>
+  zid: string
+  id: string
+  deviceType: RingDeviceType
+  categoryId: number
+  onComponentDevices: Observable<RingDevice[]>
 
   constructor(
     private initialData: RingDeviceData,
@@ -21,6 +20,15 @@ export class RingDevice extends Subscribed {
     public assetId: string
   ) {
     super()
+
+    this.onData = new BehaviorSubject(this.initialData)
+    this.zid = this.initialData.zid
+    this.id = this.zid
+    this.deviceType = this.initialData.deviceType
+    this.categoryId = this.initialData.categoryId
+    this.onComponentDevices = this.location.onDevices.pipe(
+      map((devices) => devices.filter(({ data }) => data.parentZid === this.id))
+    )
 
     this.addSubscriptions(
       location.onDeviceDataUpdate

--- a/api/ring-types.ts
+++ b/api/ring-types.ts
@@ -291,7 +291,7 @@ export interface BeamBridge {
   updated_at: string
 }
 
-type ChimeKind = 'chime' | 'chime_pro' | 'chime_v2' | 'chime_pro_v2'
+export type ChimeKind = 'chime' | 'chime_pro' | 'chime_v2' | 'chime_pro_v2'
 export const ChimeModel: { readonly [P in ChimeKind]: string } = {
   chime: 'Chime',
   chime_pro: 'Chime Pro',

--- a/api/sip-session.ts
+++ b/api/sip-session.ts
@@ -31,7 +31,7 @@ export class SipSession extends Subscribed {
   private hasStarted = false
   private hasCallEnded = false
   private onCallEndedSubject = new ReplaySubject(1)
-  private sipCall: SipCall = this.createSipCall(this.sipOptions)
+  private sipCall: SipCall
   onCallEnded = this.onCallEndedSubject.asObservable()
 
   constructor(
@@ -45,6 +45,8 @@ export class SipSession extends Subscribed {
     public readonly camera: RingCamera
   ) {
     super()
+
+    this.sipCall = this.createSipCall(this.sipOptions)
   }
 
   createSipCall(sipOptions: SipOptions) {

--- a/api/util.ts
+++ b/api/util.ts
@@ -1,4 +1,4 @@
-import debug = require('debug')
+import debug from 'debug'
 import { red } from 'colors'
 import { createInterface } from 'readline'
 import { v4 as generateRandomUuid, v5 as generateUuidFromNamespace } from 'uuid'


### PR DESCRIPTION
The primary issue is that constructor assignment members are being used by
member variable initializers. Member variables are initialized before constructor members
causing a host of null reference problems. You can view these errors
by changing compilerOptions.target to esnext.