### PR TITLE
WebRTC signaling endpoints

### DIFF
--- a/api/ring-camera.ts
+++ b/api/ring-camera.ts
@@ -691,6 +691,47 @@ export class RingCamera extends Subscribed {
     return sipSession
   }
 
+  /**
+   * Exchange an Offer SDP for an Answer SDP. Unknown if this endpoint supports trickle with
+   * the same session UUID. The Answer SDP advertises trickle. Invalid SDP will result in error
+   * 400. Calling this too often will result in what seems to be a soft lockout for 5 minutes,
+   * resulting in error 500s.
+   * @param session_uuid A session UUID that can be later used to end the WebRTC session.
+   * Unknown if stopping the session is actually necessary since WebRTC knows the peer connection state.
+   * @param sdp Offer SDP. audio channel must be set to sendrecv.
+   * @returns Answer SDP.
+   */
+  async startWebRtcSession(session_uuid: string, sdp: string): Promise<string> {
+    const response = await this.restClient.request<any>({
+      method: 'POST',
+      url: 'https://api.ring.com/integrations/v1/liveview/start',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        session_id: session_uuid,
+        device_id: this.id,
+        sdp: sdp,
+        protocol: 'webrtc',
+      }),
+    })
+    return response.sdp
+  }
+
+  async endWebRtcSession(session_uuid: string): Promise<string> {
+    const response = await this.restClient.request<any>({
+      method: 'POST',
+      url: 'https://api.ring.com/integrations/v1/liveview/end',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        session_id: session_uuid,
+      }),
+    })
+    return response.sdp
+  }
+
   subscribeToDingEvents() {
     return this.restClient.request({
       method: 'POST',


### PR DESCRIPTION
This change updates the client API to expose the signaling endpoints. Exchange an offer for an answer. Ring is very picky about the sdp! I have left comments about the sdp requirements in the code.

It didn't make much sense to convert it to an ffmpeg input in the ring client API, because the client API, imo, should provide the webrtc signaling only. Scrypted's dashboard, on the web, *will actually use this endpoint* directly to initiate browser to Ring streaming using WebRTC. (As it similarly does with Nest)

<img width="1190" alt="image" src="https://user-images.githubusercontent.com/73924/151214356-9fc0b187-9e7b-41a8-bfc8-dc5048d960d9.png">

However, other systems in Scrypted do need a WebRTC to FFmpeg conversion. This global plugin agnostic implementation can be found here:
https://github.com/koush/scrypted/blob/main/common/src/wrtc-ffmpeg-source.ts

Here are the ring plugin specific configuration options used by the aforementioned code:
https://github.com/koush/scrypted/blob/b3d574d7e6815213c26dc0372a7f2a0afc36ce53/plugins/ring/src/main.ts#L16

This can be ported to the homebridge plugin as necessary. This werift/ffmpeg code, however, is still in flux, as I'm ironing out issues between ring and nest.

