### PR TITLE
Add Name so that Logs show as Ring instead of homebridge-ring

### DIFF
--- a/homebridge/config.schema.json
+++ b/homebridge/config.schema.json
@@ -12,9 +12,7 @@
     "properties": {
       "Name": {
         "title": "Name",
-        "type": "string",
-        "required": true,
-        "default": "Ring"
+        "type": "string"
       },
       "refreshToken": {
         "title": "Refresh Token",

--- a/homebridge/config.schema.json
+++ b/homebridge/config.schema.json
@@ -10,6 +10,12 @@
   "schema": {
     "type": "object",
     "properties": {
+      "Name": {
+        "title": "Name",
+        "type": "string",
+        "required": true,
+        "default": "Ring"
+      },
       "refreshToken": {
         "title": "Refresh Token",
         "type": "string",


### PR DESCRIPTION
instead of showing in logs like this:
```
[11/15/2021, 5:07:32 PM] [homebridge-ring] Front Detected Motion. Loading snapshot before sending event to HomeKit
[11/15/2021, 5:50:08 PM] [homebridge-ring] Front Detected Motion. Loading snapshot before sending event to HomeKit
[11/15/2021, 6:30:33 PM] [homebridge-ring] Reconnecting location socket.io connection
[11/15/2021, 6:30:34 PM] [homebridge-ring] Creating location socket.io connection - Mandan
[11/15/2021, 6:30:34 PM] [homebridge-ring] Ring connected to socket.io server
[11/15/2021, 6:33:15 PM] [homebridge-ring] Front Detected Motion. Loading snapshot before sending event to HomeKit
```
It will display in logs like this:
```
[11/15/2021, 5:07:32 PM] [Ring] Front Detected Motion. Loading snapshot before sending event to HomeKit
[11/15/2021, 5:50:08 PM] [Ring] Front Detected Motion. Loading snapshot before sending event to HomeKit
[11/15/2021, 6:30:33 PM] [Ring] Reconnecting location socket.io connection
[11/15/2021, 6:30:34 PM] [Ring] Creating location socket.io connection - Mandan
[11/15/2021, 6:30:34 PM] [Ring] Ring connected to socket.io server
[11/15/2021, 6:33:15 PM] [Ring] Front Detected Motion. Loading snapshot before sending event to HomeKit
```

changed as discussed.