### PR TITLE
allow option to disable retry mechanism on no response

### DIFF
--- a/api/rest-client.ts
+++ b/api/rest-client.ts
@@ -49,7 +49,7 @@ export interface ExtendedResponse {
 }
 
 async function requestWithRetry<T>(
-  requestOptions: RequestOptions & { url: string }
+  requestOptions: RequestOptions & { url: string; allowNoResponse?: boolean }
 ): Promise<T & ExtendedResponse> {
   try {
     const options = {
@@ -66,7 +66,7 @@ async function requestWithRetry<T>(
     }
     return data
   } catch (e: any) {
-    if (!e.response) {
+    if (!e.response && !requestOptions.allowNoResponse) {
       logError(
         `Failed to reach Ring server at ${requestOptions.url}.  ${e.message}.  Trying again in 5 seconds...`
       )
@@ -315,7 +315,7 @@ export class RingRestClient {
   }
 
   async request<T = void>(
-    options: RequestOptions & { url: string }
+    options: RequestOptions & { url: string; allowNoResponse?: boolean }
   ): Promise<T & ExtendedResponse> {
     const hardwareId = await this.hardwareIdPromise,
       url = options.url! as string,


### PR DESCRIPTION
I need a way to be able to create requests with the ring api, with no retries. the current rest client will always retry on no response, which happens on snapshots. I need to manage snapshot recovery myself, and that involves knowing when the request fails, and without any retries at all.
 