### PR TITLE
various fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
   "ignorePatterns": [
     "release-*",
     "lib",
+    "lib-esnext",
     "public",
     "json-data",
     ".homebridge",

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ yarn.lock
 .homebridge
 .hoobs
 examples/test-example.ts
+lib-esnext

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [11.0.2](https://github.com/dgreif/ring/compare/v11.0.1...v11.0.2) (2022-05-22)
+
+
+### Bug Fixes
+
+* **api:** prevent duplicate events from `onCallEnded` ([14ee6eb](https://github.com/dgreif/ring/commit/14ee6eb90bb6ae568dcfd9e8e176c3001e422f9c)), closes [#941](https://github.com/dgreif/ring/issues/941)
+* handle pcmu audio streams for incoming audio ([06f6ff1](https://github.com/dgreif/ring/commit/06f6ff10ce7c8f2b05b1a12b8f244daa200fa9ab)), closes [#930](https://github.com/dgreif/ring/issues/930)
+* handle pcmu return audio ([7b86182](https://github.com/dgreif/ring/commit/7b8618261a6ccb85b9f760ee1fcc228be00fe5a6)), closes [#930](https://github.com/dgreif/ring/issues/930)
+* **homebride:** use shared engines config to enforce node 16 requirement ([b748cb0](https://github.com/dgreif/ring/commit/b748cb027db0c43ae109e1ea77c6bc83f86e4913))
+* prevent hanging promises from streams that fail to connect ([dd7638e](https://github.com/dgreif/ring/commit/dd7638e32626499c0be501be6b19b5d874fa974f))
+
 ### [11.0.1](https://github.com/dgreif/ring/compare/v11.0.0...v11.0.1) (2022-05-17)
 
 

--- a/api/rest-client.ts
+++ b/api/rest-client.ts
@@ -144,11 +144,7 @@ export class RingRestClient {
     oldRefreshToken?: string
     newRefreshToken: string
   }>(1)
-  public readonly baseSessionMetadata = {
-    api_version: apiVersion,
-    device_model:
-      this.authOptions.controlCenterDisplayName ?? 'ring-client-api',
-  }
+  public readonly baseSessionMetadata
 
   constructor(
     private authOptions: (EmailAuth | RefreshTokenAuth) & SessionOptions
@@ -158,6 +154,11 @@ export class RingRestClient {
         ? this.authOptions.refreshToken
         : undefined
     this.hardwareIdPromise = getHardwareId(this.authOptions.systemId)
+    this.baseSessionMetadata = {
+      api_version: apiVersion,
+      device_model:
+        this.authOptions.controlCenterDisplayName ?? 'ring-client-api',
+    }
   }
 
   private getGrantData(twoFactorAuthCode?: string) {

--- a/api/ring-camera.ts
+++ b/api/ring-camera.ts
@@ -141,7 +141,8 @@ export class RingCamera extends Subscribed {
     private initialData: CameraData,
     public isDoorbot: boolean,
     private restClient: RingRestClient,
-    private avoidSnapshotBatteryDrain: boolean
+    private avoidSnapshotBatteryDrain: boolean,
+    private streamingConnectionOptions: StreamingConnectionOptions
   ) {
     super()
 
@@ -338,10 +339,14 @@ export class RingCamera extends Subscribed {
     return response.device_health
   }
 
-  private async createStreamingConnection(options: StreamingConnectionOptions) {
+  private async createStreamingConnection(options?: StreamingConnectionOptions) {
     if (this.isRingEdgeEnabled) {
       const auth = await this.restClient.getCurrentAuth()
-      return new RingEdgeConnection(auth.access_token, this, options)
+      return new RingEdgeConnection(
+        auth.access_token,
+        this,
+        options || this.streamingConnectionOptions
+      )
     }
 
     const liveCall = await this.restClient
@@ -359,10 +364,14 @@ export class RingCamera extends Subscribed {
         throw e
       })
 
-    return new WebrtcConnection(liveCall.data.session_id, this, options)
+    return new WebrtcConnection(
+      liveCall.data.session_id,
+      this,
+      options || this.streamingConnectionOptions
+    )
   }
 
-  async startLiveCall(options: StreamingConnectionOptions = {}) {
+  async startLiveCall(options?: StreamingConnectionOptions) {
     const connection = await this.createStreamingConnection(options)
     return new StreamingSession(this, connection)
   }

--- a/api/ring-camera.ts
+++ b/api/ring-camera.ts
@@ -339,14 +339,18 @@ export class RingCamera extends Subscribed {
     return response.device_health
   }
 
-  private async createStreamingConnection(options?: StreamingConnectionOptions) {
+  private async createStreamingConnection(
+    options?: StreamingConnectionOptions
+  ) {
     if (this.isRingEdgeEnabled) {
-      const auth = await this.restClient.getCurrentAuth()
-      return new RingEdgeConnection(
-        auth.access_token,
-        this,
-        options || this.streamingConnectionOptions
-      )
+      const auth = await this.restClient.getCurrentAuth(),
+        ret = new RingEdgeConnection(
+          auth.access_token,
+          this,
+          options || this.streamingConnectionOptions
+        )
+      await firstValueFrom(ret.onSessionId)
+      return ret
     }
 
     const liveCall = await this.restClient

--- a/api/streaming/peer-connection.ts
+++ b/api/streaming/peer-connection.ts
@@ -1,168 +1,19 @@
-import {
-  ConnectionState,
-  MediaStreamTrack,
-  RTCIceCandidate,
-  RTCPeerConnection,
-  RtcpPacket,
-  RTCRtpCodecParameters,
-  RtpPacket,
-} from 'werift'
-import { Observable, ReplaySubject, Subject } from 'rxjs'
-import { logError, logInfo } from '../util'
-
-const debug = false,
-  ringIceServers = [
-    'stun:stun.kinesisvideo.us-east-1.amazonaws.com:443',
-    'stun:stun.kinesisvideo.us-east-2.amazonaws.com:443',
-    'stun:stun.kinesisvideo.us-west-2.amazonaws.com:443',
-    'stun:stun.l.google.com:19302',
-    'stun:stun1.l.google.com:19302',
-    'stun:stun2.l.google.com:19302',
-    'stun:stun3.l.google.com:19302',
-    'stun:stun4.l.google.com:19302',
-  ]
+import type { Observable, Subject } from 'rxjs'
+import type { ConnectionState, RTCIceCandidate, RtpPacket } from 'werift'
 
 export interface BasicPeerConnection {
+  onAudioRtp?: Subject<RtpPacket>
+  onVideoRtp?: Subject<RtpPacket>
+
   createOffer(): Promise<{ sdp: string }>
   createAnswer(offer: {
     type: 'offer'
     sdp: string
   }): Promise<RTCSessionDescriptionInit>
   acceptAnswer(answer: { type: 'answer'; sdp: string }): Promise<void>
-  addIceCandidate(candidate: RTCIceCandidate): Promise<void>
-  onIceCandidate: Observable<RTCIceCandidate>
+  addIceCandidate(candidate: RTCIceCandidateInit): Promise<void>
+  onIceCandidate: Observable<RTCIceCandidateInit>
   onConnectionState: Observable<ConnectionState>
   close(): void
-}
-
-export class WeriftPeerConnection implements BasicPeerConnection {
-  private pc
-  onAudioRtp = new Subject<RtpPacket>()
-  onAudioRtcp = new Subject<RtcpPacket>()
-  onVideoRtp = new Subject<RtpPacket>()
-  onVideoRtcp = new Subject<RtcpPacket>()
-  onIceCandidate = new Subject<RTCIceCandidate>()
-  onConnectionState = new ReplaySubject<ConnectionState>(1)
-  returnAudioTrack = new MediaStreamTrack({ kind: 'audio' })
-
-  constructor() {
-    const pc = (this.pc = new RTCPeerConnection({
-        codecs: {
-          audio: [
-            new RTCRtpCodecParameters({
-              mimeType: 'audio/opus',
-              clockRate: 48000,
-              channels: 2,
-            }),
-            new RTCRtpCodecParameters({
-              mimeType: 'audio/PCMU',
-              clockRate: 8000,
-              channels: 1,
-              payloadType: 0,
-            }),
-          ],
-          video: [
-            new RTCRtpCodecParameters({
-              mimeType: 'video/H264',
-              clockRate: 90000,
-              rtcpFeedback: [
-                { type: 'transport-cc' },
-                { type: 'ccm', parameter: 'fir' },
-                { type: 'nack' },
-                { type: 'nack', parameter: 'pli' },
-                { type: 'goog-remb' },
-              ],
-              parameters:
-                'packetization-mode=1;profile-level-id=640029;level-asymmetry-allowed=1',
-            }),
-          ],
-        },
-        iceServers: ringIceServers.map((server) => ({ urls: server })),
-        iceTransportPolicy: 'all',
-      })),
-      audioTransceiver = pc.addTransceiver(this.returnAudioTrack, {
-        direction: 'sendrecv',
-      }),
-      videoTransceiver = pc.addTransceiver('video', {
-        direction: 'recvonly',
-      })
-
-    audioTransceiver.onTrack.subscribe((track) => {
-      track.onReceiveRtp.subscribe((rtp) => {
-        this.onAudioRtp.next(rtp)
-      })
-
-      track.onReceiveRtcp.subscribe((rtcp) => {
-        this.onAudioRtcp.next(rtcp)
-      })
-
-      if (debug) {
-        track.onReceiveRtp.once(() => {
-          logInfo('received first audio packet')
-        })
-      }
-    })
-
-    videoTransceiver.onTrack.subscribe((track) => {
-      track.onReceiveRtp.subscribe((rtp) => {
-        this.onVideoRtp.next(rtp)
-      })
-
-      track.onReceiveRtcp.subscribe((rtcp) => {
-        this.onVideoRtcp.next(rtcp)
-      })
-
-      track.onReceiveRtp.once(() => {
-        if (debug) {
-          logInfo('received first video packet')
-        }
-
-        setInterval(
-          () => videoTransceiver.receiver.sendRtcpPLI(track.ssrc!),
-          2000
-        )
-      })
-    })
-    this.pc.onIceCandidate.subscribe((iceCandidate) => {
-      this.onIceCandidate.next(iceCandidate)
-    })
-
-    pc.iceConnectionStateChange.subscribe(() => {
-      logInfo(`iceConnectionStateChange: ${pc.iceConnectionState}`)
-      if (pc.iceConnectionState === 'closed') {
-        this.onConnectionState.next('closed')
-      }
-    })
-    pc.connectionStateChange.subscribe(() => {
-      logInfo(`connectionStateChange: ${pc.connectionState}`)
-      this.onConnectionState.next(pc.connectionState)
-    })
-  }
-
-  async createOffer() {
-    const offer = await this.pc.createOffer()
-    await this.pc.setLocalDescription(offer)
-
-    return offer
-  }
-
-  async createAnswer(offer: { type: 'offer'; sdp: string }) {
-    await this.pc.setRemoteDescription(offer)
-    const answer = await this.pc.createAnswer()
-    await this.pc.setLocalDescription(answer)
-
-    return answer
-  }
-
-  async acceptAnswer(answer: { type: 'answer'; sdp: string }) {
-    await this.pc.setRemoteDescription(answer)
-  }
-
-  addIceCandidate(candidate: RTCIceCandidate) {
-    return this.pc.addIceCandidate(candidate)
-  }
-
-  close() {
-    this.pc.close().catch(logError)
-  }
+  sendAudioPacket?(rtp: RtpPacket | Buffer): void
 }

--- a/api/streaming/peer-connection.ts
+++ b/api/streaming/peer-connection.ts
@@ -1,5 +1,5 @@
 import type { Observable, Subject } from 'rxjs'
-import type { ConnectionState, RTCIceCandidate, RtpPacket } from 'werift'
+import type { ConnectionState, RtpPacket } from 'werift'
 
 export interface BasicPeerConnection {
   onAudioRtp?: Subject<RtpPacket>

--- a/api/streaming/ring-edge-connection.ts
+++ b/api/streaming/ring-edge-connection.ts
@@ -1,6 +1,6 @@
 import { WebSocket } from 'ws'
 import { firstValueFrom, interval, ReplaySubject } from 'rxjs'
-import { logDebug, logError } from '../util'
+import { logDebug, logError, logInfo } from '../util'
 import { RingCamera } from '../ring-camera'
 import { switchMap } from 'rxjs/operators'
 import {
@@ -143,7 +143,6 @@ export class RingEdgeConnection extends StreamingConnectionBase {
       method: 'live_view',
       body: {
         doorbot_id: this.camera.id,
-        stream_options: { audio_enabled: true, video_enabled: true },
         sdp,
       },
     })
@@ -181,6 +180,14 @@ export class RingEdgeConnection extends StreamingConnectionBase {
       case 'sdp':
         await this.pc.acceptAnswer(message.body)
         this.onCallAnswered.next(message.body.sdp)
+
+        logInfo('Activating Session')
+        this.sendSessionMessage('activate_session')
+
+        this.sendSessionMessage('stream_options', {
+          audio_enabled: true,
+          video_enabled: true,
+        })
         return
       case 'ice':
         await this.pc.addIceCandidate({

--- a/api/streaming/streaming-connection-base.ts
+++ b/api/streaming/streaming-connection-base.ts
@@ -78,26 +78,6 @@ export abstract class StreamingConnectionBase extends Subscribed {
     body?: Record<any, any>
   ): void
 
-  private activated = false
-  activate() {
-    if (this.activated) {
-      return
-    }
-    this.activated = true
-
-    // Fire and forget this call so that callers don't get hung up waiting for connection (which might not happen)
-    firstValueFrom(
-      this.pc.onConnectionState.pipe(filter((state) => state === 'connected'))
-    )
-      .then(() => {
-        logInfo('Activating Session')
-        this.sendSessionMessage('activate_session')
-      })
-      .catch((e) => {
-        logError(e)
-      })
-  }
-
   activateCameraSpeaker() {
     // Fire and forget this call so that callers don't get hung up waiting for answer (which might not happen)
     firstValueFrom(this.onCallAnswered)

--- a/api/streaming/streaming-connection-base.ts
+++ b/api/streaming/streaming-connection-base.ts
@@ -13,8 +13,10 @@ export interface StreamingConnectionOptions {
 export abstract class StreamingConnectionBase extends Subscribed {
   readonly onCallAnswered = new ReplaySubject<string>(1)
   readonly onCallEnded = new ReplaySubject<void>(1)
+  readonly onMessage = new ReplaySubject<{ method: string }>()
   readonly onWsOpen
   protected readonly pc
+  public sessionId: string | null = null
 
   readonly onAudioRtp
   readonly onVideoRtp

--- a/api/streaming/streaming-session.ts
+++ b/api/streaming/streaming-session.ts
@@ -64,15 +64,6 @@ export class StreamingSession extends Subscribed {
     )
   }
 
-  activated = false
-  activate() {
-    if (this.activated || this.hasEnded) {
-      return
-    }
-    this.activated = true
-    this.connection.activate()
-  }
-
   cameraSpeakerActivated = false
   activateCameraSpeaker() {
     if (this.cameraSpeakerActivated || this.hasEnded) {
@@ -162,9 +153,6 @@ export class StreamingSession extends Subscribed {
     this.onCallEnded.subscribe(() => ff.stop())
 
     ff.writeStdin(inputSdp)
-
-    // Activate the stream now that ffmpeg is ready to receive
-    this.activate()
   }
 
   async transcodeReturnAudio(ffmpegOptions: { input: SpawnInput[] }) {

--- a/api/streaming/streaming-session.ts
+++ b/api/streaming/streaming-session.ts
@@ -42,11 +42,15 @@ export class StreamingSession extends Subscribed {
 
   constructor(
     private readonly camera: RingCamera,
-    private connection: RingEdgeConnection | WebrtcConnection
+    public connection: RingEdgeConnection | WebrtcConnection
   ) {
     super()
 
     this.bindToConnection(connection)
+  }
+
+  get sessionId() {
+    return this.connection.sessionId
   }
 
   private bindToConnection(connection: RingEdgeConnection | WebrtcConnection) {
@@ -55,7 +59,8 @@ export class StreamingSession extends Subscribed {
       connection.onVideoRtp.subscribe(this.onVideoRtp),
       connection.onCallAnswered.subscribe((sdp) => {
         this.onUsingOpus.next(sdp.toLocaleLowerCase().includes(' opus/'))
-      })
+      }),
+      connection.onCallEnded.subscribe(() => this.callEnded())
     )
   }
 

--- a/api/streaming/streaming-session.ts
+++ b/api/streaming/streaming-session.ts
@@ -1,4 +1,4 @@
-import { RtpPacket } from 'werift'
+import type { RtpPacket } from 'werift'
 import {
   FfmpegProcess,
   reservePorts,
@@ -168,8 +168,7 @@ export class StreamingSession extends Subscribed {
     }
 
     const audioOutForwarder = new RtpSplitter(({ message }) => {
-        const rtp = RtpPacket.deSerialize(message)
-        this.connection.sendAudioPacket(rtp)
+        this.connection.sendAudioPacket(message)
         return null
       }),
       usingOpus = await this.isUsingOpus,
@@ -221,7 +220,7 @@ export class StreamingSession extends Subscribed {
     this.callEnded()
   }
 
-  sendAudioPacket(rtp: RtpPacket) {
+  sendAudioPacket(rtp: RtpPacket | Buffer) {
     if (this.hasEnded) {
       return
     }

--- a/api/streaming/webrtc-connection.ts
+++ b/api/streaming/webrtc-connection.ts
@@ -95,6 +95,7 @@ export class WebrtcConnection extends StreamingConnectionBase {
         this.sendSessionMessage('sdp', answer)
         this.onCallAnswered.next(message.sdp)
 
+        this.sendSessionMessage('activate_session')
         this.sendSessionMessage('stream_options', {
           audio_enabled: true,
           video_enabled: true,

--- a/api/streaming/webrtc-connection.ts
+++ b/api/streaming/webrtc-connection.ts
@@ -57,7 +57,7 @@ function parseLiveCallSession(sessionId: string) {
 
 export class WebrtcConnection extends StreamingConnectionBase {
   constructor(
-    private sessionId: string,
+    public sessionId: string,
     camera: RingCamera,
     options: StreamingConnectionOptions
   ) {
@@ -87,6 +87,8 @@ export class WebrtcConnection extends StreamingConnectionBase {
   protected async handleMessage(
     message: InitializationMessage | OfferMessage | IceCandidateMessage
   ) {
+    this.onMessage.next(message)
+
     switch (message.method) {
       case 'sdp':
         const answer = await this.pc.createAnswer(message)

--- a/api/streaming/werift-peer-connection.ts
+++ b/api/streaming/werift-peer-connection.ts
@@ -1,0 +1,160 @@
+import { ReplaySubject, Subject } from 'rxjs'
+import {
+  ConnectionState,
+  MediaStreamTrack,
+  RTCIceCandidate,
+  RTCPeerConnection,
+  RtcpPacket,
+  RTCRtpCodecParameters,
+  RtpPacket,
+} from 'werift'
+import { logError, logInfo } from '../util'
+import { BasicPeerConnection } from './peer-connection'
+
+const debug = false,
+  ringIceServers = [
+    'stun:stun.kinesisvideo.us-east-1.amazonaws.com:443',
+    'stun:stun.kinesisvideo.us-east-2.amazonaws.com:443',
+    'stun:stun.kinesisvideo.us-west-2.amazonaws.com:443',
+    'stun:stun.l.google.com:19302',
+    'stun:stun1.l.google.com:19302',
+    'stun:stun2.l.google.com:19302',
+    'stun:stun3.l.google.com:19302',
+    'stun:stun4.l.google.com:19302',
+  ]
+
+export class WeriftPeerConnection implements BasicPeerConnection {
+  private pc
+  onAudioRtp = new Subject<RtpPacket>()
+  onAudioRtcp = new Subject<RtcpPacket>()
+  onVideoRtp = new Subject<RtpPacket>()
+  onVideoRtcp = new Subject<RtcpPacket>()
+  onIceCandidate = new Subject<RTCIceCandidate>()
+  onConnectionState = new ReplaySubject<ConnectionState>(1)
+  returnAudioTrack = new MediaStreamTrack({ kind: 'audio' })
+
+  constructor() {
+    const pc = (this.pc = new RTCPeerConnection({
+        codecs: {
+          audio: [
+            new RTCRtpCodecParameters({
+              mimeType: 'audio/opus',
+              clockRate: 48000,
+              channels: 2,
+            }),
+            new RTCRtpCodecParameters({
+              mimeType: 'audio/PCMU',
+              clockRate: 8000,
+              channels: 1,
+              payloadType: 0,
+            }),
+          ],
+          video: [
+            new RTCRtpCodecParameters({
+              mimeType: 'video/H264',
+              clockRate: 90000,
+              rtcpFeedback: [
+                { type: 'transport-cc' },
+                { type: 'ccm', parameter: 'fir' },
+                { type: 'nack' },
+                { type: 'nack', parameter: 'pli' },
+                { type: 'goog-remb' },
+              ],
+              parameters:
+                'packetization-mode=1;profile-level-id=640029;level-asymmetry-allowed=1',
+            }),
+          ],
+        },
+        iceServers: ringIceServers.map((server) => ({ urls: server })),
+        iceTransportPolicy: 'all',
+      })),
+      audioTransceiver = pc.addTransceiver(this.returnAudioTrack, {
+        direction: 'sendrecv',
+      }),
+      videoTransceiver = pc.addTransceiver('video', {
+        direction: 'recvonly',
+      })
+
+    audioTransceiver.onTrack.subscribe((track) => {
+      track.onReceiveRtp.subscribe((rtp) => {
+        this.onAudioRtp.next(rtp)
+      })
+
+      track.onReceiveRtcp.subscribe((rtcp) => {
+        this.onAudioRtcp.next(rtcp)
+      })
+
+      if (debug) {
+        track.onReceiveRtp.once(() => {
+          logInfo('received first audio packet')
+        })
+      }
+    })
+
+    videoTransceiver.onTrack.subscribe((track) => {
+      track.onReceiveRtp.subscribe((rtp) => {
+        this.onVideoRtp.next(rtp)
+      })
+
+      track.onReceiveRtcp.subscribe((rtcp) => {
+        this.onVideoRtcp.next(rtcp)
+      })
+
+      track.onReceiveRtp.once(() => {
+        if (debug) {
+          logInfo('received first video packet')
+        }
+
+        setInterval(
+          () => videoTransceiver.receiver.sendRtcpPLI(track.ssrc!),
+          2000
+        )
+      })
+    })
+    this.pc.onIceCandidate.subscribe((iceCandidate) => {
+      this.onIceCandidate.next(iceCandidate)
+    })
+
+    pc.iceConnectionStateChange.subscribe(() => {
+      logInfo(`iceConnectionStateChange: ${pc.iceConnectionState}`)
+      if (pc.iceConnectionState === 'closed') {
+        this.onConnectionState.next('closed')
+      }
+    })
+    pc.connectionStateChange.subscribe(() => {
+      logInfo(`connectionStateChange: ${pc.connectionState}`)
+      this.onConnectionState.next(pc.connectionState)
+    })
+  }
+
+  async createOffer() {
+    const offer = await this.pc.createOffer()
+    await this.pc.setLocalDescription(offer)
+
+    return offer
+  }
+
+  async createAnswer(offer: { type: 'offer'; sdp: string }) {
+    await this.pc.setRemoteDescription(offer)
+    const answer = await this.pc.createAnswer()
+    await this.pc.setLocalDescription(answer)
+
+    return answer
+  }
+
+  async acceptAnswer(answer: { type: 'answer'; sdp: string }) {
+    await this.pc.setRemoteDescription(answer)
+  }
+
+  addIceCandidate(candidate: RTCIceCandidate) {
+    return this.pc.addIceCandidate(candidate)
+  }
+
+  close() {
+    this.pc.close().catch(logError)
+  }
+
+  sendAudioPacket(rtp: RtpPacket | Buffer) {
+    this.returnAudioTrack.writeRtp(rtp)
+  }
+}

--- a/examples/browser-example.ts
+++ b/examples/browser-example.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config'
 import { RingApi } from '../api'
 import { promisify } from 'util'
+import { WeriftPeerConnection } from '../api/streaming/werift-peer-connection'
 const fs = require('fs'),
   path = require('path'),
   express = require('express')
@@ -15,6 +16,7 @@ async function example() {
       // Replace with your refresh token
       refreshToken: process.env.RING_REFRESH_TOKEN!,
       debug: true,
+      createPeerConnection: () => new WeriftPeerConnection(),
     }),
     [camera] = await ringApi.getCameras()
 

--- a/examples/record-example.ts
+++ b/examples/record-example.ts
@@ -2,6 +2,7 @@ import 'dotenv/config'
 import { RingApi } from '../api'
 import { cleanOutputDirectory, outputDirectory } from './util'
 import * as path from 'path'
+import { WeriftPeerConnection } from '../api/streaming/werift-peer-connection'
 
 /**
  * This example records a 10 second video clip to output/example.mp4
@@ -12,6 +13,7 @@ async function example() {
       // Replace with your refresh token
       refreshToken: process.env.RING_REFRESH_TOKEN!,
       debug: true,
+      createPeerConnection: () => new WeriftPeerConnection(),
     }),
     cameras = await ringApi.getCameras(),
     camera = cameras[0]

--- a/examples/return-audio-example.ts
+++ b/examples/return-audio-example.ts
@@ -2,6 +2,7 @@ import 'dotenv/config'
 import { RingApi } from '../api'
 import { cleanOutputDirectory } from './util'
 import * as path from 'path'
+import { WeriftPeerConnection } from '../api/streaming/werift-peer-connection'
 
 /**
  * This example takes an audio clip from examples/example.mp4 and pipes it to a ring camera
@@ -12,6 +13,7 @@ async function example() {
       // Replace with your refresh token
       refreshToken: process.env.RING_REFRESH_TOKEN!,
       debug: true,
+      createPeerConnection: () => new WeriftPeerConnection(),
     }),
     cameras = await ringApi.getCameras(),
     camera = cameras[0]

--- a/examples/stream-example.ts
+++ b/examples/stream-example.ts
@@ -2,6 +2,7 @@ import 'dotenv/config'
 import { RingApi } from '../api'
 import * as path from 'path'
 import { cleanOutputDirectory, outputDirectory } from './util'
+import { WeriftPeerConnection } from '../api/streaming/werift-peer-connection'
 
 /**
  * This example streams to files, each with 10 seconds of video.
@@ -13,6 +14,7 @@ async function example() {
       // Replace with your refresh token
       refreshToken: process.env.RING_REFRESH_TOKEN!,
       debug: true,
+      createPeerConnection: () => new WeriftPeerConnection(),
     }),
     [camera] = await ringApi.getCameras()
 

--- a/homebridge/camera-source.ts
+++ b/homebridge/camera-source.ts
@@ -192,7 +192,7 @@ class StreamingSessionWrapper {
 
     const shouldTranscodeAudio = await this.libfdkAacInstalledPromise
     if (!shouldTranscodeAudio) {
-      return this.streamingSession.activate()
+      return
     }
 
     const transcodingPromise = this.streamingSession.startTranscoding({

--- a/homebridge/location-mode-switch.ts
+++ b/homebridge/location-mode-switch.ts
@@ -33,7 +33,7 @@ function getStateFromMode(mode: LocationMode) {
 
 export class LocationModeSwitch extends BaseAccessory<Location> {
   private targetState: any
-  public device = this.location // for use in BaseAccessory
+  public device // for use in BaseAccessory
 
   constructor(
     private readonly location: Location,
@@ -42,6 +42,7 @@ export class LocationModeSwitch extends BaseAccessory<Location> {
     public readonly config: RingPlatformConfig
   ) {
     super()
+    this.device = this.location
     const {
         Characteristic,
         Service: { SecuritySystem, AccessoryInformation },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client-api",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client-api",
-      "version": "11.0.1",
+      "version": "11.0.2",
       "funding": [
         {
           "type": "paypal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client-api",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "description": "Unofficial API for Ring doorbells, cameras, security alarm system and smart lighting",
   "main": "lib/api/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "11.0.2",
   "description": "Unofficial API for Ring doorbells, cameras, security alarm system and smart lighting",
   "main": "lib/api/index.js",
+  "module": "lib-esnext/api/index.js",
   "bin": {
     "ring-auth-cli": "ring-auth-cli.js",
     "ring-device-data-cli": "ring-device-data-cli.js"
@@ -13,7 +14,7 @@
     "test": "jest && eslint '**/*.ts'",
     "watch:tests": "jest --watch",
     "lint": "eslint '**/*.ts' --fix",
-    "build": "rm -rf lib && tsc --declaration",
+    "build": "rm -rf lib && tsc --declaration && rm -rf lib-esnext && tsc -p tsconfig.esnext.json --declaration",
     "build-quick": "rm -rf lib && esbuild ./{api,examples,homebridge}/*.ts ./api/streaming/*.ts --target=es2017 --format=cjs --outdir=lib",
     "example": "node -r @swc-node/register ./examples/example.ts",
     "api-example": "node -r @swc-node/register ./examples/api-example.ts",

--- a/tsconfig.esnext.json
+++ b/tsconfig.esnext.json
@@ -1,12 +1,14 @@
 {
   "compilerOptions": {
-    "target":"ES2021",
+    "target":"esnext",
     "lib": [
-      "ES2021",
+      "es5",
+      "es2015",
+      "es2017",
       "dom"
     ],
     "module": "commonjs",
-    "outDir": "./lib",
+    "outDir": "./lib-esnext",
     "esModuleInterop": true,
     "allowJs": true,
     "strict": true


### PR DESCRIPTION
This builds on top of https://github.com/dgreif/ring/pull/952

do not return the ring edge connection until it has confirmed with a session id.
connection call ended should end the streaming session.
add raw connection onMessage to diagnose/debug the connection.
fix race condition in sendSessionMessage if sessionId is not available yet
generate random client ids for the ring edge session. seems to fix weird early terminations of other streaming sessions, and matches what is seen in the browser.
remove bundle sdp hack. this was fixed in a werift pull request.