### PR TITLE
Enable retransmission of lost RTP packets via RTX

### DIFF
--- a/packages/ring-client-api/streaming/peer-connection.ts
+++ b/packages/ring-client-api/streaming/peer-connection.ts
@@ -82,6 +82,10 @@ export class WeriftPeerConnection
               parameters:
                 'packetization-mode=1;profile-level-id=640029;level-asymmetry-allowed=1',
             }),
+            new RTCRtpCodecParameters({
+              mimeType: "video/rtx",
+              clockRate: 90000,
+            }),
           ],
         },
         iceServers: ringIceServers.map((server) => ({ urls: server })),

--- a/packages/ring-client-api/streaming/peer-connection.ts
+++ b/packages/ring-client-api/streaming/peer-connection.ts
@@ -83,7 +83,7 @@ export class WeriftPeerConnection
                 'packetization-mode=1;profile-level-id=640029;level-asymmetry-allowed=1',
             }),
             new RTCRtpCodecParameters({
-              mimeType: "video/rtx",
+              mimeType: 'video/rtx',
               clockRate: 90000,
             }),
           ],


### PR DESCRIPTION
Hi @dgreif ,

For months I've been plagued by random artificing when viewing streams with ring-client-api and I finally had time to dig into it.  For a while I thought this was some problem with werift itself, perhaps just poor performance overall, but after adding some debugging it was clear that, for my case UDP packets were occassionally lost before they reached even my firewall.

What didn't make sense was that videos viewed with the Ring app or Ring web dashboard on the same device/network never experienced this issue so I took some packet traces and really started digging into it and finally I noticed that both the Ring web dahsboard and app use RTX to support retransmission of lost packets.  You can see the same occassional packet loss in the streams viewing in Google browser, but any loss followed quickly by RTCP feedback telling the upstream that packets were lost, and then, within 100ms or so, a retransmit on the channel via RTX payload type.

Taking the same trace from the same Ring media server by using ring-client-api with werift showed that a packet would be lost, and werift would send RTCP feedback just the same, but no retransmitted packet was ever seen.  On further digging I noticed that the SDP offer received via the websocket included RTX, but the answer created by werift did not, thus there was no way for packets to retransmit even though feedback was being sent.  Adding this small patch allows werift to produce and SDP answer that includes RTX payload type and indeed, the behavior then matches what is seen when using a browser.  This dramatically decreases artifacts in my streams.  Please consider including in a future version.