### PR TITLE
Fix polling when only intercoms exist

### DIFF
--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -166,7 +166,7 @@ export class RingApi extends Subscribed {
         return byId
       }, {} as { [id: number]: RingIntercom })
 
-    if (!cameras.length && !chimes.length) {
+    if (!cameras.length && !chimes.length && !intercoms.length) {
       return
     }
 


### PR DESCRIPTION
Hi @dgreif,

While adding support for intercoms to ring-mqtt I had one user that had really strange behavior in that his device would go offline after a few minutes.  To determine if a device without a websocket is online/offline I use a simple heartbeat function which relies on the fact that onData function for polled devices is called every 20 seconds.  For this user, this polling never happened, and even if I manually called requestUpdate() I would just get no response.  However, when I ran the same code on my account, it worked.

The only real difference between my account and the users account is that I also have cameras and chimes, while this user only had an intercom and, after some digging, it looks like this is caused by the check in listenForDeviceUpdates() which returns prior to subscribing for update events if it doesn't find any cameras or chimes.  I'm assuming this was in error so I'm submitting this PR which also checks for intercoms before returning so that polling is enabled even if a user has only intercoms.