### PR TITLE
fix: 406 error

### DIFF
--- a/packages/ring-client-api/rest-client.ts
+++ b/packages/ring-client-api/rest-client.ts
@@ -200,6 +200,7 @@ export class RingRestClient {
         },
         method: 'POST',
         headers: {
+          'User-Agent': 'Ring/6.9.0 (Nokia; Nokia 6.1; Android 9)',
           '2fa-support': 'true',
           '2fa-code': twoFactorAuthCode || '',
           hardware_id: await this.hardwareIdPromise,


### PR DESCRIPTION
Hi,

Adding `User-Agent` header fixes issue mentioned in #1192 

```
TypeError: Cannot use 'in' operator to search for 'error' in <html>
<head><title>406 Not Acceptable</title></head>
<body bgcolor="white">
<center><h1>406 Not Acceptable</h1></center>
<hr><center>nginx</center>
</body>
</html>
```