### PR TITLE
Return information for both batteries

### DIFF
--- a/packages/ring-client-api/ring-camera.ts
+++ b/packages/ring-client-api/ring-camera.ts
@@ -65,25 +65,26 @@ function getEndOfToday() {
   return getStartOfToday() + fullDayMs - 1
 }
 
+interface BatteryLevel {
+  primary: number | null,
+  secondary: number | null
+}
+
 export function getBatteryLevel(
   data: Pick<CameraData, 'battery_life' | 'battery_life_2'> & {
     health?: Partial<CameraData['health']>
   }
-) {
-  const levels = [
-      parseBatteryLife(data.battery_life),
-      parseBatteryLife(data.battery_life_2),
-    ].filter((level): level is number => level !== null),
-    { health } = data
+): BatteryLevel | null {
+  const { health } = data
 
-  if (
-    !levels.length ||
-    (health && !health.battery_percentage && !health.battery_present)
-  ) {
+  if (health && !health.battery_percentage && !health.battery_present) {
     return null
   }
 
-  return Math.min(...levels)
+  return {
+    primary: parseBatteryLife(data.battery_life),
+    secondary: parseBatteryLife(data.battery_life_2)
+  }
 }
 
 export function getSearchQueryString(

--- a/packages/ring-client-api/test/ring-camera.spec.ts
+++ b/packages/ring-client-api/test/ring-camera.spec.ts
@@ -6,33 +6,42 @@ describe('Ring Camera', () => {
       expect(
         getBatteryLevel({
           battery_life: '49',
+          battery_life_2: '50'
         })
-      ).toEqual(49)
+      ).toEqual({ primary: 49, secondary: 50 })
+    })
+
+    it('should handle string battery life (no secondary)', () => {
+      expect(
+        getBatteryLevel({
+          battery_life: '49'
+        })
+      ).toEqual({ primary: 49, secondary: null })
     })
 
     it('should handle null battery life', () => {
-      expect(getBatteryLevel({ battery_life: null })).toEqual(null)
+      expect(getBatteryLevel({ battery_life: null })).toEqual({ primary: null, secondary: null })
     })
 
     it('should handle right battery only', () => {
       expect(
         getBatteryLevel({ battery_life: null, battery_life_2: 24 })
-      ).toEqual(24)
+      ).toEqual({ primary: null, secondary: 24 })
     })
 
     it('should handle left battery only', () => {
       expect(
         getBatteryLevel({ battery_life: 76, battery_life_2: null })
-      ).toEqual(76)
+      ).toEqual({ primary: 76, secondary: null })
     })
 
     it('should handle dual batteries', () => {
       expect(
         getBatteryLevel({ battery_life: '92', battery_life_2: 84 })
-      ).toEqual(84)
+      ).toEqual({ primary: 92, secondary: 84 })
       expect(
         getBatteryLevel({ battery_life: '92', battery_life_2: 100 })
-      ).toEqual(92)
+      ).toEqual({ primary: 92, secondary: 100 })
     })
   })
 


### PR DESCRIPTION
For devices that support two batteries, the current logic to get the battery level returns the minimum of the two batteries.

I need to check the level of both batteries separately and think it would be preferable not to discard the greater of the two levels. I have updated the code to return an object with `primary` and `secondary` fields to show the level of each battery for devices with two batteries. In single-battery devices, only the `primary` field will have a value. 