### PR TITLE
Support complete dingId

### DIFF
--- a/.changeset/real-onions-tickle.md
+++ b/.changeset/real-onions-tickle.md
@@ -2,4 +2,4 @@
 'ring-client-api': patch
 ---
 
-breaking: treat ding id as a string for complete precision
+Update push notifications to include a full and accurate ding `id`. Note, this is technically a breaking change because the `id` was previously a `number` instead of a `string`, but the last few digits were truncated due to number rounding. We are releasing this as a patch because the `number` version was unusable for fetching additional information about the ding.

--- a/.changeset/real-onions-tickle.md
+++ b/.changeset/real-onions-tickle.md
@@ -1,0 +1,5 @@
+---
+'ring-client-api': patch
+---
+
+breaking: treat ding id as a string for complete precision

--- a/package-lock.json
+++ b/package-lock.json
@@ -5353,6 +5353,12 @@
       "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz",
       "integrity": "sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g=="
     },
+    "node_modules/@types/json-bigint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/json-bigint/-/json-bigint-1.0.1.tgz",
+      "integrity": "sha512-zpchZLNsNuzJHi6v64UBoFWAvQlPhch7XAi36FkH6tL1bbbmimIF+cS7vwkzY4u5RaSWMoflQfu+TshMPPw8uw==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -23137,6 +23143,7 @@
       "devDependencies": {
         "@types/debug": "4.1.7",
         "@types/jest": "29.5.0",
+        "@types/json-bigint": "^1.0.1",
         "@types/node": "18.15.9",
         "@types/uuid": "9.0.1",
         "@types/ws": "^8.5.4",
@@ -27143,6 +27150,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz",
       "integrity": "sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g=="
+    },
+    "@types/json-bigint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/json-bigint/-/json-bigint-1.0.1.tgz",
+      "integrity": "sha512-zpchZLNsNuzJHi6v64UBoFWAvQlPhch7XAi36FkH6tL1bbbmimIF+cS7vwkzY4u5RaSWMoflQfu+TshMPPw8uw==",
+      "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.11",
@@ -37726,6 +37739,7 @@
         "@peculiar/webcrypto": "^1.4.3",
         "@types/debug": "4.1.7",
         "@types/jest": "29.5.0",
+        "@types/json-bigint": "*",
         "@types/node": "18.15.9",
         "@types/socket.io-client": "1.4.36",
         "@types/uuid": "9.0.1",
@@ -37735,7 +37749,7 @@
         "eslint-config-shared": "*",
         "got": "^11.8.5",
         "jest": "29.5.0",
-        "json-bigint": "*",
+        "json-bigint": "^1.0.0",
         "msw": "^1.2.1",
         "rxjs": "^7.8.0",
         "socket.io-client": "^2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37739,7 +37739,7 @@
         "@peculiar/webcrypto": "^1.4.3",
         "@types/debug": "4.1.7",
         "@types/jest": "29.5.0",
-        "@types/json-bigint": "*",
+        "@types/json-bigint": "^1.0.1",
         "@types/node": "18.15.9",
         "@types/socket.io-client": "1.4.36",
         "@types/uuid": "9.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7040,6 +7040,14 @@
         "node": "*"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-data": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/binary-data/-/binary-data-0.6.0.tgz",
@@ -14074,6 +14082,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -23104,6 +23120,7 @@
         "colors": "1.4.0",
         "debug": "^4.3.4",
         "got": "^11.8.5",
+        "json-bigint": "^1.0.0",
         "msw": "^1.2.1",
         "rxjs": "^7.8.0",
         "socket.io-client": "^2.5.0",
@@ -28376,6 +28393,11 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
+    },
+    "bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig=="
     },
     "binary-data": {
       "version": "0.6.0",
@@ -33745,6 +33767,14 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -37705,6 +37735,7 @@
         "eslint-config-shared": "*",
         "got": "^11.8.5",
         "jest": "29.5.0",
+        "json-bigint": "*",
         "msw": "^1.2.1",
         "rxjs": "^7.8.0",
         "socket.io-client": "^2.5.0",

--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -29,6 +29,7 @@ import { setFfmpegPath } from './ffmpeg'
 import { Subscribed } from './subscribed'
 import PushReceiver from '@eneris/push-receiver'
 import { RingIntercom } from './ring-intercom'
+import JSONbig = require('json-bigint')
 
 export interface RingApiOptions extends SessionOptions {
   locationIds?: string[]
@@ -270,7 +271,7 @@ export class RingApi extends Subscribed {
       const dataJson = message.data?.gcmData as string
 
       try {
-        const notification = JSON.parse(dataJson) as PushNotification
+        const notification = JSONbig({ storeAsString: true }).parse(dataJson) as PushNotification
 
         if ('ding' in notification) {
           sendToDevice(notification.ding.doorbot_id, notification)

--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -271,7 +271,9 @@ export class RingApi extends Subscribed {
       const dataJson = message.data?.gcmData as string
 
       try {
-        const notification = JSONbig({ storeAsString: true }).parse(dataJson) as PushNotification
+        const notification = JSONbig({ storeAsString: true }).parse(
+          dataJson
+        ) as PushNotification
 
         if ('ding' in notification) {
           sendToDevice(notification.ding.doorbot_id, notification)

--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -29,7 +29,7 @@ import { setFfmpegPath } from './ffmpeg'
 import { Subscribed } from './subscribed'
 import PushReceiver from '@eneris/push-receiver'
 import { RingIntercom } from './ring-intercom'
-import JSONbig = require('json-bigint')
+import JSONbig from 'json-bigint'
 
 export interface RingApiOptions extends SessionOptions {
   locationIds?: string[]

--- a/packages/ring-client-api/package.json
+++ b/packages/ring-client-api/package.json
@@ -25,6 +25,7 @@
     "colors": "1.4.0",
     "debug": "^4.3.4",
     "got": "^11.8.5",
+    "json-bigint": "^1.0.0",
     "msw": "^1.2.1",
     "rxjs": "^7.8.0",
     "socket.io-client": "^2.5.0",

--- a/packages/ring-client-api/package.json
+++ b/packages/ring-client-api/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@types/debug": "4.1.7",
     "@types/jest": "29.5.0",
+    "@types/json-bigint": "^1.0.1",
     "@types/node": "18.15.9",
     "@types/uuid": "9.0.1",
     "@types/ws": "^8.5.4",

--- a/packages/ring-client-api/ring-camera.ts
+++ b/packages/ring-client-api/ring-camera.ts
@@ -398,7 +398,7 @@ export class RingCamera extends Subscribed {
     return new StreamingSession(this, connection)
   }
 
-  private removeDingById(idToRemove: number) {
+  private removeDingById(idToRemove: string) {
     const allActiveDings = this.activeNotifications,
       otherDings = allActiveDings.filter(({ ding }) => ding.id !== idToRemove)
 

--- a/packages/ring-client-api/ring-types.ts
+++ b/packages/ring-client-api/ring-types.ts
@@ -1016,7 +1016,7 @@ export interface PushNotificationDing {
     device_kind: RingCameraKind
     detection_type: NotificationDetectionType
     human_detected?: boolean
-    id: number
+    id: string
     pod_id: number
     request_id: string
     image_uuid: string


### PR DESCRIPTION
Since the switch to push notifications, the dingId has been parsed as a number, which loses the last three digits of precision. This makes it impossible to use that dingId to look up dings in the ring history.

This change switches to parsing the ding payload with `json-bigint` and the ding ID field is now a string to store the id to its complete precision.