### PR TITLE
Refresh support

### DIFF
--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -47,7 +47,10 @@ export interface RingApiOptions extends SessionOptions {
 export class RingApi extends Subscribed {
   public readonly restClient
   public readonly onRefreshTokenUpdated
-  onNewNotification = new Subject<{ device:RingCamera | RingIntercom, notification:PushNotification }>()
+  onNewNotification = new Subject<{
+    device: RingCamera | RingIntercom
+    notification: PushNotification
+  }>()
 
   constructor(public readonly options: RingApiOptions & RefreshTokenAuth) {
     super()
@@ -213,23 +216,23 @@ export class RingApi extends Subscribed {
     }
   }
 
-  pushReceiver : PushReceiver | undefined;
-  devicesById: { [id: number]: RingCamera | RingIntercom | undefined } = {};
+  pushReceiver: PushReceiver | undefined
+  devicesById: { [id: number]: RingCamera | RingIntercom | undefined } = {}
 
   private async registerPushReceiver(
     cameras: RingCamera[],
     intercoms: RingIntercom[]
   ) {
     const sendToDevice = (id: number, notification: PushNotification) => {
-        const device = this.devicesById[id];
+        const device = this.devicesById[id]
         if (device) {
-          this.onNewNotification.next({ device, notification });
-          device.processPushNotification(notification);
+          this.onNewNotification.next({ device, notification })
+          device.processPushNotification(notification)
         }
       },
       onPushNotificationToken = new Subject<string>()
 
-    this.devicesById = {};
+    this.devicesById = {}
     for (const camera of cameras) {
       this.devicesById[camera.id] = camera
     }
@@ -238,15 +241,15 @@ export class RingApi extends Subscribed {
     }
 
     if (this.pushReceiver) {
-      return;
+      return
     }
 
     const pushReceiver = new PushReceiver({
       logLevel: 'NONE',
       senderId: '876313859327', // for Ring android app.  703521446232 for ring-site
-    });
+    })
 
-    this.pushReceiver = pushReceiver;
+    this.pushReceiver = pushReceiver
 
     pushReceiver.onCredentialsChanged(
       ({
@@ -440,9 +443,9 @@ export class RingApi extends Subscribed {
   }
 
   refresh() {
-    this.disconnect();
+    this.disconnect()
     if (this.locationsPromise) {
-      this.locationsPromise = this.fetchAndBuildLocations();
+      this.locationsPromise = this.fetchAndBuildLocations()
     }
   }
 }


### PR DESCRIPTION
Adds support for `RingAPI::refresh()` which will allow all the locations and cameras to be reloaded.

This keeps the existing push receiver and just updates the map it uses to send out notifications. Additionally this adds a blanked `onNewNotification` subject to the `RingApi` so that a client can receive dings from cameras without the need to resubscribe to all the cameras after a refresh.