### PR TITLE
Tweak ffmpeg Opus encoding optoins for more reliable audio

### DIFF
--- a/.changeset/tame-onions-trade.md
+++ b/.changeset/tame-onions-trade.md
@@ -1,0 +1,5 @@
+---
+'homebridge-ring': patch
+---
+
+Improve 2-way audio quality in homebridge

--- a/package-lock.json
+++ b/package-lock.json
@@ -11992,12 +11992,12 @@
         "dotenv": "16.3.1",
         "eslint-config-shared": "*",
         "express": "4.18.2",
-        "ring-client-api": "12.0.0-beta.2",
+        "ring-client-api": "12.0.0-beta.3",
         "tsconfig": "*"
       }
     },
     "packages/homebridge-ring": {
-      "version": "12.0.0-beta.2",
+      "version": "12.0.0-beta.3",
       "funding": [
         {
           "type": "paypal",
@@ -12012,8 +12012,8 @@
       "dependencies": {
         "@homebridge/camera-utils": "^2.2.0",
         "@homebridge/plugin-ui-utils": "^0.1.0",
-        "ring-client-api": "12.0.0-beta.2",
-        "werift": "0.17.6"
+        "ring-client-api": "12.0.0-beta.3",
+        "werift": "0.18.5"
       },
       "devDependencies": {
         "concurrently": "^8.2.0",
@@ -12028,52 +12028,8 @@
         "node": "^18 || ^20"
       }
     },
-    "packages/homebridge-ring/node_modules/@minhducsun2002/leb128": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@minhducsun2002/leb128/-/leb128-0.2.0.tgz",
-      "integrity": "sha512-XckPQO6CDP0LAg3ZHIBZcjIWXgdM5vGhwhixZU78UEwaXwc33LXPl1KfvV8jCyrdU2YzplCvaNK3Mm0MDh6t1Q=="
-    },
-    "packages/homebridge-ring/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "packages/homebridge-ring/node_modules/werift": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/werift/-/werift-0.17.6.tgz",
-      "integrity": "sha512-9ObiSKocRDdwvEhJnDDFTi4jLgcjmAhIv/jlJ+yh3faLsAQUi32EEIB2XMiFiTwVMaVqrK5mvKA8KyTJKESRSA==",
-      "dependencies": {
-        "@fidm/x509": "^1.2.1",
-        "@minhducsun2002/leb128": "^0.2.0",
-        "@peculiar/webcrypto": "^1.4.0",
-        "@peculiar/x509": "^1.7.2",
-        "@shinyoshiaki/ebml-builder": "^0.0.1",
-        "aes-js": "^3.1.2",
-        "binary-data": "^0.6.0",
-        "buffer-crc32": "^0.2.13",
-        "date-fns": "^2.28.0",
-        "debug": "^4.3.4",
-        "elliptic": "^6.5.3",
-        "int64-buffer": "^1.0.1",
-        "ip": "^1.1.8",
-        "jspack": "^0.0.4",
-        "lodash": "^4.17.20",
-        "nano-time": "^1.0.0",
-        "p-cancelable": "^2.1.1",
-        "rx.mini": "^1.1.0",
-        "turbo-crc32": "^1.0.1",
-        "tweetnacl": "^1.0.3",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "packages/ring-client-api": {
-      "version": "12.0.0-beta.2",
+      "version": "12.0.0-beta.3",
       "funding": [
         {
           "type": "paypal",
@@ -16544,7 +16500,7 @@
         "dotenv": "16.3.1",
         "eslint-config-shared": "*",
         "express": "4.18.2",
-        "ring-client-api": "12.0.0-beta.2",
+        "ring-client-api": "12.0.0-beta.3",
         "tsconfig": "*"
       }
     },
@@ -17222,50 +17178,10 @@
         "eslint-config-shared": "*",
         "homebridge": "1.6.1",
         "nodemon": "^3.0.1",
-        "ring-client-api": "12.0.0-beta.2",
+        "ring-client-api": "12.0.0-beta.3",
         "tsconfig": "*",
         "typescript": "5.1.6",
-        "werift": "0.17.6"
-      },
-      "dependencies": {
-        "@minhducsun2002/leb128": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/@minhducsun2002/leb128/-/leb128-0.2.0.tgz",
-          "integrity": "sha512-XckPQO6CDP0LAg3ZHIBZcjIWXgdM5vGhwhixZU78UEwaXwc33LXPl1KfvV8jCyrdU2YzplCvaNK3Mm0MDh6t1Q=="
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        },
-        "werift": {
-          "version": "0.17.6",
-          "resolved": "https://registry.npmjs.org/werift/-/werift-0.17.6.tgz",
-          "integrity": "sha512-9ObiSKocRDdwvEhJnDDFTi4jLgcjmAhIv/jlJ+yh3faLsAQUi32EEIB2XMiFiTwVMaVqrK5mvKA8KyTJKESRSA==",
-          "requires": {
-            "@fidm/x509": "^1.2.1",
-            "@minhducsun2002/leb128": "^0.2.0",
-            "@peculiar/webcrypto": "^1.4.0",
-            "@peculiar/x509": "^1.7.2",
-            "@shinyoshiaki/ebml-builder": "^0.0.1",
-            "aes-js": "^3.1.2",
-            "binary-data": "^0.6.0",
-            "buffer-crc32": "^0.2.13",
-            "date-fns": "^2.28.0",
-            "debug": "^4.3.4",
-            "elliptic": "^6.5.3",
-            "int64-buffer": "^1.0.1",
-            "ip": "^1.1.8",
-            "jspack": "^0.0.4",
-            "lodash": "^4.17.20",
-            "nano-time": "^1.0.0",
-            "p-cancelable": "^2.1.1",
-            "rx.mini": "^1.1.0",
-            "turbo-crc32": "^1.0.1",
-            "tweetnacl": "^1.0.3",
-            "uuid": "^8.3.2"
-          }
-        }
+        "werift": "0.18.5"
       }
     },
     "hosted-git-info": {

--- a/packages/homebridge-ring/camera-source.ts
+++ b/packages/homebridge-ring/camera-source.ts
@@ -348,7 +348,19 @@ class StreamingSessionWrapper {
         outputArgs: [
           '-acodec',
           ...(isRingUsingOpus
-            ? ['libopus', '-ac', 1, '-ar', '24k', '-vbr', 'off', '-b:a', '24k', '-application', 'voip']
+            ? [
+                'libopus',
+                '-ac',
+                1,
+                '-ar',
+                '24k',
+                '-vbr',
+                'off',
+                '-b:a',
+                '24k',
+                '-application',
+                'voip',
+              ]
             : ['pcm_mulaw', '-ac', 1, '-ar', '8k']),
           '-flags',
           '+global_header',

--- a/packages/homebridge-ring/camera-source.ts
+++ b/packages/homebridge-ring/camera-source.ts
@@ -273,7 +273,9 @@ class StreamingSessionWrapper {
               '-frame_duration',
               request.audio.packet_time,
               '-application',
-              'lowdelay',
+              'voip',
+              '-vbr',
+              'off',
             ]
           : [
               // AAC-eld specific
@@ -346,7 +348,7 @@ class StreamingSessionWrapper {
         outputArgs: [
           '-acodec',
           ...(isRingUsingOpus
-            ? ['libopus', '-ac', 2, '-ar', '48k']
+            ? ['libopus', '-ac', 1, '-ar', '24k', '-vbr', 'off', '-b:a', '24k', '-application', 'voip']
             : ['pcm_mulaw', '-ac', 1, '-ar', '8k']),
           '-flags',
           '+global_header',

--- a/packages/homebridge-ring/package.json
+++ b/packages/homebridge-ring/package.json
@@ -14,7 +14,7 @@
     "@homebridge/camera-utils": "^2.2.0",
     "@homebridge/plugin-ui-utils": "^0.1.0",
     "ring-client-api": "12.0.0-beta.3",
-    "werift": "0.17.6"
+    "werift": "0.18.5"
   },
   "devDependencies": {
     "concurrently": "^8.2.0",


### PR DESCRIPTION
These changes are pretty minor.  Based on what I could determine, the audio from the doorbell was single channel, 24Khz sample rate, and a 24Kb bitrate, so this uses the same for the return audio.  Also, disabled Opus variable bit rate, this seems to reduce the stuttering and overall robot sounding voice as well as works around the issues with recent werift versions.

The audio quality is still not as good as that from the Ring app, I'm not sure if this is due to Homekit audio, the transcoding itself (although I tried a lot of different options and this seemed to be the best), or if Ring is doing some type of audio filtering.  The audio from Ring seems lower pitched, like they are filtering it through an equalizer or lowpass filter, which perhaps they are because the speakers in these devices don't do well with higher pitches.

I may play with this some, but for now, this seems better than the previous results, at least for the cameras I have access to.
