### PR TITLE
Fix ffmpeg error when streaming over LTE/5G

### DIFF
--- a/.changeset/poor-moles-cry.md
+++ b/.changeset/poor-moles-cry.md
@@ -1,0 +1,6 @@
+---
+'homebridge-ring': patch
+---
+
+ Update Opus processing to handle all possible bitrates and packet lengths which should fix audio issues over LTE/5G
+ Minor tweaks to AAC-ELD processing for slightly improved audio

--- a/packages/homebridge-ring/camera-source.ts
+++ b/packages/homebridge-ring/camera-source.ts
@@ -157,11 +157,15 @@ class StreamingSessionWrapper {
         audio: { port: audioPort },
       } = this.prepareStreamRequest,
       {
-        audio: { codec: audioCodec, sample_rate: audioSampleRate, packet_time: audioPacketTime },
+        audio: {
+          codec: audioCodec,
+          sample_rate: audioSampleRate,
+          packet_time: audioPacketTime,
+        },
       } = startStreamRequest,
       // Repacketize the audio stream after it's been transcoded
       opusRepacketizer = new OpusRepacketizer(audioPacketTime / 20),
-      audioIntervalScale = (audioSampleRate / 8) * audioPacketTime / 20,
+      audioIntervalScale = ((audioSampleRate / 8) * audioPacketTime) / 20,
       audioSrtpSession = new SrtpSession(getSessionConfig(this.audioSrtp))
 
     let firstTimestamp: number,
@@ -283,7 +287,7 @@ class StreamingSessionWrapper {
               '-eld_sbr:a',
               '1',
               '-eld_v2',
-              '1'
+              '1',
             ]),
 
         // Shared options
@@ -320,7 +324,7 @@ class StreamingSessionWrapper {
 
         // deserialize and send to Ring - werift will handle encryption and other header params
         try {
-          let rtp: RtpPacket | undefined = RtpPacket.deSerialize(message)
+          const rtp: RtpPacket | undefined = RtpPacket.deSerialize(message)
           this.streamingSession.sendAudioPacket(rtp)
         } catch (_) {
           // deSerialize will sometimes fail, but the errors can be ignored

--- a/packages/homebridge-ring/camera-source.ts
+++ b/packages/homebridge-ring/camera-source.ts
@@ -303,7 +303,7 @@ class StreamingSessionWrapper {
         '-f',
         'rtp',
         `rtp://127.0.0.1:${await this.repacketizeAudioSplitter
-          .portPromise}?pkt_size=276`,
+          .portPromise}`,
       ],
       video: false,
       output: [],

--- a/packages/homebridge-ring/camera-source.ts
+++ b/packages/homebridge-ring/camera-source.ts
@@ -303,7 +303,7 @@ class StreamingSessionWrapper {
         '-f',
         'rtp',
         `rtp://127.0.0.1:${await this.repacketizeAudioSplitter
-          .portPromise}?pkt_size=188`,
+          .portPromise}?pkt_size=276`,
       ],
       video: false,
       output: [],

--- a/packages/homebridge-ring/opus-repacketizer.ts
+++ b/packages/homebridge-ring/opus-repacketizer.ts
@@ -17,7 +17,6 @@ import type { RtpPacket } from 'werift'
 // |                                                               |
 // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-
 // OUTPUT
 
 // 0                   1                   2                   3
@@ -46,7 +45,6 @@ import type { RtpPacket } from 'werift'
 // :                  Opus Padding (Optional)...                   |
 // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-
 //                  Figure 6: A CBR Code 3 Packet
 
 // In the VBR case, the (optional) padding length is followed by M-1
@@ -65,123 +63,121 @@ import type { RtpPacket } from 'werift'
 // size of the packet.
 
 export class OpusRepacketizer {
-    depacketized: Buffer[] = [];
+  depacketized: Buffer[] = []
 
-    constructor(public framesPerPacket: number) {
+  constructor(public framesPerPacket: number) {}
+
+  // repacketize a packet with a single frame into a packet with multiple frames.
+  repacketize(packet: RtpPacket): RtpPacket | undefined {
+    const code = packet.payload[0] & 0b00000011
+    let offset: number
+
+    // see Frame Length Coding in RFC
+    const decodeFrameLength = () => {
+      let frameLength = packet.payload.readUInt8(offset)
+      if (frameLength >= 252) {
+        offset++
+        frameLength += packet.payload.readUInt8(offset) * 4
+      }
+      return frameLength
+    }
+    // code 0: cbr, 1 packet
+    // code 1: cbr, 2 packets
+    // code 2: vbr, 2 packets
+    // code 3: cbr/vbr signaled, variable packets
+
+    if (code === 0) {
+      if (this.framesPerPacket === 1 && !this.depacketized.length) return packet
+      // depacketize by stripping off the config byte
+      this.depacketized.push(packet.payload.subarray(1))
+    } else if (code === 1) {
+      if (this.framesPerPacket === 2 && !this.depacketized.length) return packet
+      // depacketize by dividing the remaining payload into two equal sized frames
+      const remaining = packet.payload.length - 1
+      if (remaining % 2) {
+        throw new Error('expected equal sized opus packets (code 1)')
+      }
+      const frameLength = remaining / 2
+      this.depacketized.push(packet.payload.subarray(1, 1 + frameLength))
+      this.depacketized.push(packet.payload.subarray(1 + frameLength))
+    } else if (code === 2) {
+      if (this.framesPerPacket === 2 && !this.depacketized.length) return packet
+      offset = 1
+      // depacketize by dividing the remaining payload into two inequal sized frames
+      const frameLength = decodeFrameLength()
+      this.depacketized.push(
+        packet.payload.subarray(offset, offset + frameLength),
+      )
+      this.depacketized.push(packet.payload.subarray(offset + frameLength))
+    } else if (code === 3) {
+      // code 3 packet will have a frame count and padding indicator, and whether the packets
+      // are equal size or not.
+      const frameCountByte = packet.payload[1],
+        packetFrameCount = frameCountByte & 0b00111111,
+        vbr = frameCountByte & 0b10000000
+      if (
+        this.framesPerPacket === packetFrameCount &&
+        !this.depacketized.length
+      ) {
+        return packet
+      }
+      const paddingIndicator = frameCountByte & 0b01000000
+      offset = 2
+      let padding = 0
+      if (paddingIndicator) {
+        padding = packet.payload.readUInt8(offset)
+        offset++
+        if (padding === 255) {
+          padding = 254 + packet.payload.readUInt8(offset)
+          offset++
+        }
+      }
+
+      if (!vbr) {
+        const remaining = packet.payload.length - offset - padding
+        if (remaining % packetFrameCount) {
+          throw new Error('expected equal sized opus packets (code 3)')
+        }
+        const frameLength = remaining / packetFrameCount
+        for (let i = 0; i < packetFrameCount; i++) {
+          const start = offset + i * frameLength,
+            end = start + frameLength
+          this.depacketized.push(packet.payload.subarray(start, end))
+        }
+      } else {
+        const frameLengths: number[] = []
+        for (let i = 0; i < packetFrameCount; i++) {
+          const frameLength = decodeFrameLength()
+          frameLengths.push(frameLength)
+        }
+        for (let i = 0; i < packetFrameCount; i++) {
+          const frameLength = frameLengths[i],
+            start = offset
+          offset += frameLength
+          this.depacketized.push(packet.payload.subarray(start, offset))
+        }
+      }
     }
 
-    // repacketize a packet with a single frame into a packet with multiple frames.
-    repacketize(packet: RtpPacket): RtpPacket | undefined {
-        const code = packet.payload[0] & 0b00000011;
-        let offset: number;
+    if (this.depacketized.length < this.framesPerPacket) return
 
-        // see Frame Length Coding in RFC
-        const decodeFrameLength = () => {
-            let frameLength = packet.payload.readUInt8(offset);
-            if (frameLength >= 252) {
-                offset++;
-                frameLength += packet.payload.readUInt8(offset) * 4;
-            }
-            return frameLength;
-        }
-        // code 0: cbr, 1 packet
-        // code 1: cbr, 2 packets
-        // code 2: vbr, 2 packets
-        // code 3: cbr/vbr signaled, variable packets
+    const depacketized = this.depacketized.slice(0, this.framesPerPacket)
+    this.depacketized = this.depacketized.slice(this.framesPerPacket)
 
-        if (code === 0) {
-            if (this.framesPerPacket === 1 && !this.depacketized.length)
-                return packet;
-            // depacketize by stripping off the config byte
-            this.depacketized.push(packet.payload.subarray(1));
-        }
-        else if (code === 1) {
-            if (this.framesPerPacket === 2 && !this.depacketized.length)
-                return packet;
-            // depacketize by dividing the remaining payload into two equal sized frames
-            const remaining = packet.payload.length - 1;
-            if (remaining % 2)
-                throw new Error('expected equal sized opus packets (code 1)');
-            const frameLength = remaining / 2;
-            this.depacketized.push(packet.payload.subarray(1, 1 + frameLength));
-            this.depacketized.push(packet.payload.subarray(1 + frameLength));
-        }
-        else if (code === 2) {
-            if (this.framesPerPacket === 2 && !this.depacketized.length)
-                return packet;
-            offset = 1;
-            // depacketize by dividing the remaining payload into two inequal sized frames
-            const frameLength = decodeFrameLength();
-            this.depacketized.push(packet.payload.subarray(offset, offset + frameLength));
-            this.depacketized.push(packet.payload.subarray(offset + frameLength));
-        }
-        else if (code === 3) {
-            // code 3 packet will have a frame count and padding indicator, and whether the packets
-            // are equal size or not.
-            const frameCountByte = packet.payload[1];
-            const packetFrameCount = frameCountByte & 0b00111111;
-            const vbr = frameCountByte & 0b10000000;
-            if (this.framesPerPacket === packetFrameCount && !this.depacketized.length)
-                return packet;
-            const paddingIndicator = frameCountByte & 0b01000000;
-            offset = 2;
-            let padding = 0;
-            if (paddingIndicator) {
-                padding = packet.payload.readUInt8(offset);
-                offset++;
-                if (padding === 255) {
-                    padding = 254 + packet.payload.readUInt8(offset);
-                    offset++;
-                }
-            }
+    // reuse the config and stereo indicator, but change the code to 3.
+    let toc = packet.payload[0]
+    toc |= 0b00000011
+    // vbr | padding indicator | packet count
+    const frameCountByte = 0b10000000 | this.framesPerPacket,
+      newHeader: number[] = [toc, frameCountByte]
 
-            if (!vbr) {
-                const remaining = packet.payload.length - offset - padding;
-                if (remaining % packetFrameCount)
-                    throw new Error('expected equal sized opus packets (code 3)');
-                const frameLength = remaining / packetFrameCount;
-                for (let i = 0; i < packetFrameCount; i++) {
-                    const start = offset + i * frameLength;
-                    const end = start + frameLength;
-                    this.depacketized.push(packet.payload.subarray(start, end));
-                }
-            }
-            else {
-                const frameLengths: number[] = [];
-                for (let i = 0; i < packetFrameCount; i++) {
-                    const frameLength = decodeFrameLength();
-                    frameLengths.push(frameLength);
-                }
-                for (let i = 0; i < packetFrameCount; i++) {
-                    const frameLength = frameLengths[i];
-                    const start = offset;
-                    offset += frameLength;
-                    this.depacketized.push(packet.payload.subarray(start, offset));
-                }
-            }
-        }
+    // M-1 length bytes
+    newHeader.push(...depacketized.slice(0, -1).map((data) => data.length))
 
-        if (this.depacketized.length < this.framesPerPacket)
-            return;
+    const headerBuffer = Buffer.from(newHeader),
+      payload = Buffer.concat([headerBuffer, ...depacketized])
 
-        const depacketized = this.depacketized.slice(0, this.framesPerPacket);
-        this.depacketized = this.depacketized.slice(this.framesPerPacket);
-
-        // reuse the config and stereo indicator, but change the code to 3.
-        let toc = packet.payload[0];
-        toc = toc | 0b00000011;
-        // vbr | padding indicator | packet count
-        let frameCountByte = 0b10000000 | this.framesPerPacket;
-
-        const newHeader: number[] = [toc, frameCountByte];
-
-        // M-1 length bytes
-        newHeader.push(...depacketized.slice(0, -1).map(data => data.length));
-
-        const headerBuffer = Buffer.from(newHeader);
-        const payload = Buffer.concat([headerBuffer, ...depacketized]);
-
-        packet.payload = payload;
-        return packet;
-    }
+    packet.payload = payload
+    return packet
+  }
 }

--- a/packages/homebridge-ring/opus-repacketizer.ts
+++ b/packages/homebridge-ring/opus-repacketizer.ts
@@ -1,9 +1,12 @@
 // OpusRepacketizer is borrowed from scrypted
-// Original source: https://github.com/koush/scrypted/blob/c13ba09889c3e0d9d3724cb7d49253c9d787fb97/plugins/homekit/src/types/camera/opus-repacketizer.ts
+// Original source: https://github.com/koush/scrypted/blob/3150a3033515a3886af1e6b35a0ba7432b63e02b/plugins/homekit/src/types/camera/opus-repacketizer.ts
 
 import type { RtpPacket } from 'werift'
+
 // https://datatracker.ietf.org/doc/html/rfc6716
-// INPUT
+
+// INPUT (for single frame sample, see RFC for other 4 code values)
+
 // 0                   1                   2                   3
 // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -13,7 +16,10 @@ import type { RtpPacket } from 'werift'
 // :                                                               |
 // |                                                               |
 // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
 // OUTPUT
+
 // 0                   1                   2                   3
 // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -39,7 +45,10 @@ import type { RtpPacket } from 'werift'
 // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 // :                  Opus Padding (Optional)...                   |
 // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
 //                  Figure 6: A CBR Code 3 Packet
+
 // In the VBR case, the (optional) padding length is followed by M-1
 // frame lengths (indicated by "N1" to "N[M-1]" in Figure 7), each
 // encoded in a one- or two-byte sequence as described above.  The
@@ -54,33 +63,125 @@ import type { RtpPacket } from 'werift'
 // the signaled length of the first M-1 frames themselves, plus the
 // signaled length of the padding MUST be no larger than N, the total
 // size of the packet.
-export class OpusRepacketizer {
-  packets: RtpPacket[] = []
-  constructor(public framesPerPacket: number) {}
 
-  // repacketize a packet with a single frame into a packet with multiple frames.
-  repacketize(packet: RtpPacket): RtpPacket | undefined {
-    if (this.framesPerPacket === 1) return packet
-    if (packet.payload[0] & 0b00000011) {
-      throw new Error('expected opus packet with a single frame.')
+export class OpusRepacketizer {
+    depacketized: Buffer[] = [];
+
+    constructor(public framesPerPacket: number) {
     }
-    this.packets.push(packet)
-    if (this.packets.length !== this.framesPerPacket) {
-      return
+
+    // repacketize a packet with a single frame into a packet with multiple frames.
+    repacketize(packet: RtpPacket): RtpPacket | undefined {
+        const code = packet.payload[0] & 0b00000011;
+        let offset: number;
+
+        // see Frame Length Coding in RFC
+        const decodeFrameLength = () => {
+            let frameLength = packet.payload.readUInt8(offset);
+            if (frameLength >= 252) {
+                offset++;
+                frameLength += packet.payload.readUInt8(offset) * 4;
+            }
+            return frameLength;
+        }
+        // code 0: cbr, 1 packet
+        // code 1: cbr, 2 packets
+        // code 2: vbr, 2 packets
+        // code 3: cbr/vbr signaled, variable packets
+
+        if (code === 0) {
+            if (this.framesPerPacket === 1 && !this.depacketized.length)
+                return packet;
+            // depacketize by stripping off the config byte
+            this.depacketized.push(packet.payload.subarray(1));
+        }
+        else if (code === 1) {
+            if (this.framesPerPacket === 2 && !this.depacketized.length)
+                return packet;
+            // depacketize by dividing the remaining payload into two equal sized frames
+            const remaining = packet.payload.length - 1;
+            if (remaining % 2)
+                throw new Error('expected equal sized opus packets (code 1)');
+            const frameLength = remaining / 2;
+            this.depacketized.push(packet.payload.subarray(1, 1 + frameLength));
+            this.depacketized.push(packet.payload.subarray(1 + frameLength));
+        }
+        else if (code === 2) {
+            if (this.framesPerPacket === 2 && !this.depacketized.length)
+                return packet;
+            offset = 1;
+            // depacketize by dividing the remaining payload into two inequal sized frames
+            const frameLength = decodeFrameLength();
+            this.depacketized.push(packet.payload.subarray(offset, offset + frameLength));
+            this.depacketized.push(packet.payload.subarray(offset + frameLength));
+        }
+        else if (code === 3) {
+            // code 3 packet will have a frame count and padding indicator, and whether the packets
+            // are equal size or not.
+            const frameCountByte = packet.payload[1];
+            const packetFrameCount = frameCountByte & 0b00111111;
+            const vbr = frameCountByte & 0b10000000;
+            if (this.framesPerPacket === packetFrameCount && !this.depacketized.length)
+                return packet;
+            const paddingIndicator = frameCountByte & 0b01000000;
+            offset = 2;
+            let padding = 0;
+            if (paddingIndicator) {
+                padding = packet.payload.readUInt8(offset);
+                offset++;
+                if (padding === 255) {
+                    padding = 254 + packet.payload.readUInt8(offset);
+                    offset++;
+                }
+            }
+
+            if (!vbr) {
+                const remaining = packet.payload.length - offset - padding;
+                if (remaining % packetFrameCount)
+                    throw new Error('expected equal sized opus packets (code 3)');
+                const frameLength = remaining / packetFrameCount;
+                for (let i = 0; i < packetFrameCount; i++) {
+                    const start = offset + i * frameLength;
+                    const end = start + frameLength;
+                    this.depacketized.push(packet.payload.subarray(start, end));
+                }
+            }
+            else {
+                const frameLengths: number[] = [];
+                for (let i = 0; i < packetFrameCount; i++) {
+                    const frameLength = decodeFrameLength();
+                    frameLengths.push(frameLength);
+                }
+                for (let i = 0; i < packetFrameCount; i++) {
+                    const frameLength = frameLengths[i];
+                    const start = offset;
+                    offset += frameLength;
+                    this.depacketized.push(packet.payload.subarray(start, offset));
+                }
+            }
+        }
+
+        if (this.depacketized.length < this.framesPerPacket)
+            return;
+
+        const depacketized = this.depacketized.slice(0, this.framesPerPacket);
+        this.depacketized = this.depacketized.slice(this.framesPerPacket);
+
+        // reuse the config and stereo indicator, but change the code to 3.
+        let toc = packet.payload[0];
+        toc = toc | 0b00000011;
+        // vbr | padding indicator | packet count
+        let frameCountByte = 0b10000000 | this.framesPerPacket;
+
+        const newHeader: number[] = [toc, frameCountByte];
+
+        // M-1 length bytes
+        newHeader.push(...depacketized.slice(0, -1).map(data => data.length));
+
+        const headerBuffer = Buffer.from(newHeader);
+        const payload = Buffer.concat([headerBuffer, ...depacketized]);
+
+        packet.payload = payload;
+        return packet;
     }
-    const first = this.packets[0],
-      depacketized = this.packets.map((p) => p.payload.subarray(1))
-    this.packets = []
-    let config = first.payload[0]
-    config |= 0b00000011
-    const frameCount = 0b10000000 | this.framesPerPacket,
-      newHeader: number[] = [config, frameCount]
-    // depacketize by stripping off the config byte
-    // M-1 length bytes
-    newHeader.push(...depacketized.slice(0, -1).map((data) => data.length))
-    const headerBuffer = Buffer.from(newHeader),
-      payload = Buffer.concat([headerBuffer, ...depacketized])
-    packet.payload = payload
-    return packet
-  }
 }


### PR DESCRIPTION
Super small fix here.  I appears the tweaks to Opus encoding which disabled variable bitrate encoding caused ffmpeg to produce RTP packets which slight exceed the current maximum configured packet size of 188 (176 data bytes).

This size works over local networks because Homekit requests a packet time (frame size) of 20ms which produces packets of ~60-80 bytes.  However, over LTE/5G network Homekit requests packet time of 60ms, which produces packets of 3x that size, or 180-240 bytes, which is over the hardcoded 188 byte size.  This causes ffmpeg to exit unexpectedly due to RTP packet size too big error and thus streaming will not work over LTE/5G networks (I'm not convinced this is not a bug with ffmpeg, as I would have expected the packet to be fragmented, but I don't really understand the code path here).

However, simply increasing the packet size seems to prevent the ffmpeg process from crashing.  This probably will not fix all issues with LTE/5G streaming, but it will fix this critical issue which keeps streaming from working in most cases.

I'm not 100% sure why this value was set to begin with.  In my testing the 276 byte value seems to be sufficient, but I wonder if we need any setting here at all since packet size should largely be dictated by bitrate and frame size parameters which are already explicitly set.  @dgreif perhaps you have some history here you could share?
