### PR TITLE
Motion detection switch

### DIFF
--- a/packages/homebridge-ring/camera.ts
+++ b/packages/homebridge-ring/camera.ts
@@ -117,6 +117,19 @@ export class Camera extends BaseDataAccessory<RingCamera> {
       })
     }
 
+    if (device.hasMotionDetection && !config.hideCameraMotionDetectionSwitch) {
+      this.registerCharacteristic({
+        characteristicType: Characteristic.On,
+        serviceType: Service.Switch,
+        name: device.name + ' Motion Detection Enabled',
+        getValue: (data) => {
+          return Boolean(data.settings.motion_detection_enabled)
+        },
+        setValue: (value) => device.setMotionDetectionEnabled(value),
+        requestUpdate: () => device.requestUpdate(),
+      })
+    }
+
     if (device.hasSiren && !config.hideCameraSirenSwitch) {
       this.registerCharacteristic({
         characteristicType: Characteristic.On,

--- a/packages/homebridge-ring/config.schema.json
+++ b/packages/homebridge-ring/config.schema.json
@@ -44,6 +44,10 @@
         "title": "Hide Camera Motion Sensors",
         "type": "boolean"
       },
+      "hideCameraMotionDetectionSwitch": {
+        "title": "Hide Camera Motion Detection Switch",
+        "type": "boolean"
+      },      
       "hideCameraSirenSwitch": {
         "title": "Hide Camera Siren Switch",
         "type": "boolean"
@@ -163,6 +167,7 @@
         "hideDoorbellSwitch",
         "hideCameraLight",
         "hideCameraMotionSensor",
+        "hideCameraMotionDetectionSwitch",
         "hideCameraSirenSwitch",
         "hideInHomeDoorbellSwitch",
         "hideAlarmSirenSwitch",

--- a/packages/homebridge-ring/config.ts
+++ b/packages/homebridge-ring/config.ts
@@ -15,6 +15,7 @@ export interface RingPlatformConfig extends RingApiOptions {
   hideDoorbellSwitch?: boolean
   hideCameraLight?: boolean
   hideCameraMotionSensor?: boolean
+  hideCameraMotionDetectionSwitch?: boolean
   hideCameraSirenSwitch?: boolean
   hideInHomeDoorbellSwitch?: boolean
   hideAlarmSirenSwitch?: boolean

--- a/packages/ring-client-api/ring-camera.ts
+++ b/packages/ring-client-api/ring-camera.ts
@@ -125,6 +125,7 @@ export class RingCamera extends Subscribed {
   onData
   hasLight
   hasSiren
+  hasMotionDetection
 
   onRequestUpdate = new Subject()
   onNewNotification = new Subject<PushNotificationDing>()
@@ -169,6 +170,8 @@ export class RingCamera extends Subscribed {
     this.onData = new BehaviorSubject<AnyCameraData>(this.initialData)
     this.hasLight = this.initialData.led_status !== undefined
     this.hasSiren = this.initialData.siren_status !== undefined
+    this.hasMotionDetection =
+      this.initialData.settings.motion_detection_enabled !== undefined
 
     this.onBatteryLevel = this.onData.pipe(
       map((data) => {
@@ -312,6 +315,27 @@ export class RingCamera extends Subscribed {
     this.updateData({ ...this.data, led_status: state })
 
     return true
+  }
+
+  async setMotionDetectionEnabled(enabled: boolean) {
+    if (!this.hasMotionDetection) {
+      return false
+    }
+
+    const motionReq = {
+      motion_settings: {
+        motion_detection_enabled: enabled,
+      },
+    }
+    await this.setDeviceSettings(motionReq)
+
+    const settings = {
+      ...this.data.settings,
+      motion_detection_enabled: enabled,
+    }
+
+    this.updateData({ ...this.data, settings: settings })
+    return enabled
   }
 
   async setSiren(on: boolean) {

--- a/packages/ring-client-api/ring-camera.ts
+++ b/packages/ring-client-api/ring-camera.ts
@@ -322,12 +322,12 @@ export class RingCamera extends Subscribed {
       return false
     }
 
-    const motionReq = {
+    const motionEnabledRequest = {
       motion_settings: {
         motion_detection_enabled: enabled,
       },
     }
-    await this.setDeviceSettings(motionReq)
+    await this.setDeviceSettings(motionEnabledRequest)
 
     const settings = {
       ...this.data.settings,


### PR DESCRIPTION
Add a motion detection switch characteristic to cameras. 
Allows individual camera motion detection to be enabled/disabled independently to the ring modes.

Use case: An automation to turn cameras on at night when alarm is disarmed.