### PR TITLE
Fix batteryLevel to check secondary battery

### DIFF
--- a/packages/ring-client-api/ring-camera.ts
+++ b/packages/ring-client-api/ring-camera.ts
@@ -81,7 +81,10 @@ export function getBatteryLevel(
 
   if (
     !levels.length ||
-    (health && !health.battery_percentage && !health.battery_present)
+    (health &&
+      !health.battery_percentage &&
+      !health.battery_present &&
+      !health.second_battery_percentage)
   ) {
     return null
   }

--- a/packages/ring-client-api/ring-types.ts
+++ b/packages/ring-client-api/ring-types.ts
@@ -562,6 +562,7 @@ export interface BaseCameraData {
     rssi_category: 'good' | string
     battery_voltage_category: 'very_good' | string
     second_battery_voltage_category: 'unknown' | string
+    second_battery_percentage?: number // 0 - 100
     second_battery_percentage_category: 'unknown' | string
     battery_save: boolean
     firmware_version_status: 'Up to Date'


### PR DESCRIPTION
The current logic checks only the primary battery even each camera has a secondary battery.
This PR fixes this issue by checking the secondary battery in getBatteryLevel method.

Related issue: #1312 