### PR TITLE
Update appApi  endpoint

### DIFF
--- a/.changeset/mighty-steaks-itch.md
+++ b/.changeset/mighty-steaks-itch.md
@@ -1,0 +1,6 @@
+---
+'homebridge-ring': patch
+'ring-client-api': patch
+---
+
+Update app API endpoint to fix socket connection issues

--- a/packages/ring-client-api/rest-client.ts
+++ b/packages/ring-client-api/rest-client.ts
@@ -34,7 +34,7 @@ const defaultRequestOptions: RequestOptions = {
   clientApiBaseUrl = 'https://api.ring.com/clients_api/',
   deviceApiBaseUrl = 'https://api.ring.com/devices/v1/',
   commandsApiBaseUrl = 'https://api.ring.com/commands/v1/',
-  appApiBaseUrl = 'https://app.ring.com/api/v1/',
+  appApiBaseUrl = 'https://prd-api-us.prd.rings.solutions/api/v1/',
   apiVersion = 11
 
 export function clientApi(path: string) {


### PR DESCRIPTION
This PR addresses the recently introduced API changes which appears to have disabled the legacy app.ring.com URL which prevents tickets for socket connections from being acquired.  This patch updates the URL with the one used by current versions of the Ring android app which seems to effectively work around the issue.