### PR TITLE
Don't send old FCM tokens when new token is generated during startup

### DIFF
--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -233,7 +233,8 @@ export class RingApi extends Subscribed {
     intercoms: RingIntercom[],
   ) {
     const credentials =
-        this.restClient._internalOnly_pushNotificationCredentials?.config && this.restClient._internalOnly_pushNotificationCredentials,
+        this.restClient._internalOnly_pushNotificationCredentials?.config &&
+        this.restClient._internalOnly_pushNotificationCredentials,
       pushReceiver = new PushReceiver({
         firebase: {
           apiKey: 'AIzaSyCv-hdFBmmdBBJadNy-TFwB-xN_H5m3Bk8',

--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -233,7 +233,7 @@ export class RingApi extends Subscribed {
     intercoms: RingIntercom[],
   ) {
     const credentials =
-        this.restClient._internalOnly_pushNotificationCredentials,
+        this.restClient._internalOnly_pushNotificationCredentials?.config && this.restClient._internalOnly_pushNotificationCredentials,
       pushReceiver = new PushReceiver({
         firebase: {
           apiKey: 'AIzaSyCv-hdFBmmdBBJadNy-TFwB-xN_H5m3Bk8',
@@ -241,7 +241,7 @@ export class RingApi extends Subscribed {
           messagingSenderId: '876313859327', // for Ring android app.  703521446232 for ring-site
           appId: '1:876313859327:android:e10ec6ddb3c81f39',
         },
-        credentials: credentials?.config ? credentials : undefined,
+        credentials,
         debug: false,
       }),
       devicesById: { [id: number]: RingCamera | RingIntercom | undefined } = {},

--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -358,8 +358,11 @@ export class RingApi extends Subscribed {
       }
     })
 
-    // If we already have credentials, use them immediately
-    if (credentials) {
+    // If we already have credentials and they haven't been changed during registration, use them immediately
+    if (
+      credentials?.fcm?.token ===
+      this.restClient._internalOnly_pushNotificationCredentials?.fcm?.token
+    ) {
       onPushNotificationToken.next(credentials.fcm.token)
     }
   }

--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -232,16 +232,17 @@ export class RingApi extends Subscribed {
     cameras: RingCamera[],
     intercoms: RingIntercom[],
   ) {
-    const pushReceiver = new PushReceiver({
+    const credentials =
+        this.restClient._internalOnly_pushNotificationCredentials?.config &&
+        this.restClient._internalOnly_pushNotificationCredentials,
+      pushReceiver = new PushReceiver({
         firebase: {
           apiKey: 'AIzaSyCv-hdFBmmdBBJadNy-TFwB-xN_H5m3Bk8',
           projectId: 'ring-17770',
           messagingSenderId: '876313859327', // for Ring android app.  703521446232 for ring-site
           appId: '1:876313859327:android:e10ec6ddb3c81f39',
         },
-        credentials:
-          this.restClient._internalOnly_pushNotificationCredentials?.config &&
-          this.restClient._internalOnly_pushNotificationCredentials,
+        credentials,
         debug: false,
       }),
       devicesById: { [id: number]: RingCamera | RingIntercom | undefined } = {},
@@ -358,11 +359,8 @@ export class RingApi extends Subscribed {
     })
 
     // If we already have credentials, use them immediately
-    if (this.restClient._internalOnly_pushNotificationCredentials?.fcm?.token) {
-      // Use the source in case credentials were updated prior to
-      onPushNotificationToken.next(
-        this.restClient._internalOnly_pushNotificationCredentials.fcm.token,
-      )
+    if (credentials) {
+      onPushNotificationToken.next(credentials.fcm.token)
     }
   }
 

--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -232,17 +232,16 @@ export class RingApi extends Subscribed {
     cameras: RingCamera[],
     intercoms: RingIntercom[],
   ) {
-    const credentials =
-        this.restClient._internalOnly_pushNotificationCredentials?.config &&
-        this.restClient._internalOnly_pushNotificationCredentials,
-      pushReceiver = new PushReceiver({
+    const pushReceiver = new PushReceiver({
         firebase: {
           apiKey: 'AIzaSyCv-hdFBmmdBBJadNy-TFwB-xN_H5m3Bk8',
           projectId: 'ring-17770',
           messagingSenderId: '876313859327', // for Ring android app.  703521446232 for ring-site
           appId: '1:876313859327:android:e10ec6ddb3c81f39',
         },
-        credentials,
+        credentials:
+          this.restClient._internalOnly_pushNotificationCredentials?.config &&
+          this.restClient._internalOnly_pushNotificationCredentials,
         debug: false,
       }),
       devicesById: { [id: number]: RingCamera | RingIntercom | undefined } = {},
@@ -359,8 +358,11 @@ export class RingApi extends Subscribed {
     })
 
     // If we already have credentials, use them immediately
-    if (credentials) {
-      onPushNotificationToken.next(credentials.fcm.token)
+    if (this.restClient._internalOnly_pushNotificationCredentials?.fcm?.token) {
+      // Use the source in case credentials were updated prior to
+      onPushNotificationToken.next(
+        this.restClient._internalOnly_pushNotificationCredentials.fcm.token,
+      )
     }
   }
 


### PR DESCRIPTION
This fix stops the code from pushing the old FCM token to Ring when a new token is generated during registration, for example, due to migration to FCMv1 APIs for registration.  The bug happens because the very last command in the push notification initialization sequence currently sends the FCM token to Ring any time  `credentials` is defined:
```
if (credentials) {
  onPushNotificationToken.next(credentials.fcm.token)
}
```
The problem with this is `credentials` is assigned prior to registration so it would still hold the old FCM token even if a new token was generated during the registration process.  Because of this, the sequence of events was something like this:

1) credentials = config.pnc (assuming credentials already existed)
2) Push notification would register using existing credentials
3) If registration updated the FCM token, `onCredentialsChanged()` was called which subsequently pushed the new generated FCM token to Ring
4) However, because `crendentials` was previously defined and still contained the old FCM token, the command noted above would also run immediately pushing the old FCM token back to Ring thus making it impossible to receive notifications with the new push registration

The new code only pushes the stored FCM token if it was unchanged during registration.
