### PR TITLE
Fixes for HAP-NodeJS v1.0.0

### DIFF
--- a/packages/homebridge-ring/base-accessory.ts
+++ b/packages/homebridge-ring/base-accessory.ts
@@ -132,10 +132,7 @@ export abstract class BaseAccessory<T extends { name: string }> {
   }
 
   pruneUnusedServices() {
-    const safeServiceUUIDs = [
-      hap.Service.CameraRTPStreamManagement.UUID,
-      hap.Service.CameraControl.UUID,
-    ]
+    const safeServiceUUIDs = [hap.Service.CameraRTPStreamManagement.UUID]
 
     this.accessory.services.forEach((service) => {
       if (

--- a/packages/homebridge-ring/base-device-accessory.ts
+++ b/packages/homebridge-ring/base-device-accessory.ts
@@ -100,17 +100,17 @@ export abstract class BaseDeviceAccessory extends BaseDataAccessory<RingDevice> 
     if (hasBatteryStatus(initialData)) {
       this.registerCharacteristic({
         characteristicType: Characteristic.BatteryLevel,
-        serviceType: Service.BatteryService,
+        serviceType: Service.Battery,
         getValue: getBatteryLevel,
       })
       this.registerCharacteristic({
         characteristicType: Characteristic.StatusLowBattery,
-        serviceType: Service.BatteryService,
+        serviceType: Service.Battery,
         getValue: getStatusLowBattery,
       })
       this.registerCharacteristic({
         characteristicType: Characteristic.ChargingState,
-        serviceType: Service.BatteryService,
+        serviceType: Service.Battery,
         getValue: getBatteryChargingState,
       })
     }

--- a/packages/homebridge-ring/camera.ts
+++ b/packages/homebridge-ring/camera.ts
@@ -179,7 +179,7 @@ export class Camera extends BaseDataAccessory<RingCamera> {
     if (device.hasBattery) {
       this.registerCharacteristic({
         characteristicType: Characteristic.StatusLowBattery,
-        serviceType: Service.BatteryService,
+        serviceType: Service.Battery,
         getValue: () => {
           return device.hasLowBattery
             ? StatusLowBattery.BATTERY_LEVEL_LOW
@@ -189,7 +189,7 @@ export class Camera extends BaseDataAccessory<RingCamera> {
 
       this.registerCharacteristic({
         characteristicType: Characteristic.ChargingState,
-        serviceType: Service.BatteryService,
+        serviceType: Service.Battery,
         getValue: () => {
           return device.isCharging
             ? ChargingState.CHARGING
@@ -199,7 +199,7 @@ export class Camera extends BaseDataAccessory<RingCamera> {
 
       this.registerObservableCharacteristic({
         characteristicType: Characteristic.BatteryLevel,
-        serviceType: Service.BatteryService,
+        serviceType: Service.Battery,
         onValue: device.onBatteryLevel.pipe(
           map((batteryLevel) => {
             return batteryLevel === null ? 100 : batteryLevel

--- a/packages/homebridge-ring/intercom.ts
+++ b/packages/homebridge-ring/intercom.ts
@@ -116,7 +116,7 @@ export class Intercom extends BaseDataAccessory<RingIntercom> {
     if (device.batteryLevel !== null) {
       this.registerObservableCharacteristic({
         characteristicType: Characteristic.BatteryLevel,
-        serviceType: Service.BatteryService,
+        serviceType: Service.Battery,
         onValue: device.onBatteryLevel.pipe(
           map((batteryLevel) => {
             return batteryLevel === null ? 100 : batteryLevel


### PR DESCRIPTION
This updated or removes old depreciated code that has now been removed from HAP-NodeJS v1.0.0 which will be included in a future version of Homebridge.

Until this is resolved Users that try to use the current Homebridge beta, they will get the following error:
```
[7/10/2024, 9:27:49 PM] [Ring] Error connecting to API
[7/10/2024, 9:27:49 PM] [Ring] TypeError: Cannot read properties of undefined (reading 'UUID')
    at Accessory.addService (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Accessory.ts:522:37)
    at PlatformAccessory.addService (/usr/local/lib/node_modules/homebridge/src/platformAccessory.ts:93:41)
    at Beam.getService (/usr/local/lib/node_modules/homebridge-ring/lib/base-accessory.js:29:28)
    at Beam.registerCharacteristic (/usr/local/lib/node_modules/homebridge-ring/lib/base-data-accessory.js:10:30)
    at Beam.initBase (/usr/local/lib/node_modules/homebridge-ring/lib/base-device-accessory.js:75:18)
    at /usr/local/lib/node_modules/homebridge-ring/lib/ring-platform.js:247:27
    at Array.forEach (<anonymous>)
    at /usr/local/lib/node_modules/homebridge-ring/lib/ring-platform.js:207:24
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0)
```