### PR TITLE
Handle iceCandidate event with no candidate

### DIFF
--- a/packages/ring-client-api/streaming/webrtc-connection.ts
+++ b/packages/ring-client-api/streaming/webrtc-connection.ts
@@ -132,16 +132,18 @@ export class WebrtcConnection extends Subscribed {
       }),
 
       this.pc.onIceCandidate.subscribe(async (iceCandidate) => {
-        await firstValueFrom(this.onOfferSent)
-        this.sendMessage({
-          method: 'ice',
-          dialog_id: this.dialogId,
-          body: {
-            doorbot_id: camera.id,
-            ice: iceCandidate.candidate,
-            mlineindex: iceCandidate.sdpMLineIndex,
-          },
-        })
+        if (iceCandidate?.candidate) {
+          await firstValueFrom(this.onOfferSent)
+          this.sendMessage({
+            method: 'ice',
+            dialog_id: this.dialogId,
+            body: {
+              doorbot_id: camera.id,
+              ice: iceCandidate.candidate,
+              mlineindex: iceCandidate.sdpMLineIndex,
+            },
+          })
+        }
       }),
     )
   }


### PR DESCRIPTION
This PR addresses compatibility with WeRIFT v.0.20.0 and later which modified onIceCandidate behavior to be the same as browser API.  Receiving an iceCandidate event with no candidate means all candidates are gathered.

This code just ignores evens with no candidate property, but we could also add an else and log ICE gathering complete for debug purposes if you think that is useful.