### PR TITLE
Tune fetch for improved connection management

### DIFF
--- a/.changeset/purple-teachers-applaud.md
+++ b/.changeset/purple-teachers-applaud.md
@@ -1,0 +1,6 @@
+---
+'ring-client-api': patch
+'homebridge-ring': patch
+---
+
+Increase keepalive and adjust connection pooling, which will hopefully result in more stable fetch requests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1459,9 +1459,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
       "dependencies": {
         "levn": "^0.4.1"
@@ -9878,6 +9878,15 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -10814,6 +10823,7 @@
         "rxjs": "^7.8.1",
         "socket.io-client": "^2.5.0",
         "systeminformation": "^5.23.5",
+        "undici": "^6.21.0",
         "uuid": "^11.0.3",
         "werift": "0.20.1",
         "ws": "^8.18.0"
@@ -12005,9 +12015,9 @@
       "dev": true
     },
     "@eslint/plugin-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
       "requires": {
         "levn": "^0.4.1"
@@ -17753,6 +17763,7 @@
         "ts-jest": "29.2.5",
         "tsconfig": "*",
         "typescript": "5.6.3",
+        "undici": "^6.21.0",
         "uuid": "^11.0.3",
         "werift": "0.20.1",
         "ws": "^8.18.0"
@@ -18399,6 +18410,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true
+    },
+    "undici": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw=="
     },
     "undici-types": {
       "version": "6.19.8",

--- a/packages/ring-client-api/package.json
+++ b/packages/ring-client-api/package.json
@@ -26,6 +26,7 @@
     "rxjs": "^7.8.1",
     "socket.io-client": "^2.5.0",
     "systeminformation": "^5.23.5",
+    "undici": "^6.21.0",
     "uuid": "^11.0.3",
     "werift": "0.20.1",
     "ws": "^8.18.0"

--- a/packages/ring-client-api/rest-client.ts
+++ b/packages/ring-client-api/rest-client.ts
@@ -16,14 +16,21 @@ import {
 import { ReplaySubject } from 'rxjs'
 import assert from 'assert'
 import type { Credentials } from '@eneris/push-receiver/dist/types'
+import { Agent } from 'undici'
 
 interface RequestOptions extends RequestInit {
   responseType?: 'json' | 'buffer'
   timeout?: number
   json?: object
+  dispatcher?: Agent
 }
 
-const defaultRequestOptions: RequestOptions = {
+const fetchAgent = new Agent({
+    connections: 6,
+    pipelining: 1,
+    keepAliveTimeout: 115000,
+  }),
+  defaultRequestOptions: RequestOptions = {
     responseType: 'json',
     method: 'GET',
     timeout: 20000,
@@ -116,6 +123,7 @@ async function requestWithRetry<T>(
     const options = {
       ...defaultRequestOptions,
       ...requestOptions,
+      dispatcher: fetchAgent,
     }
 
     // If a timeout is provided, create an AbortSignal for it
@@ -501,7 +509,6 @@ export class RingRestClient {
           authorization: `Bearer ${authTokenResponse.access_token}`,
           hardware_id: hardwareId,
           'User-Agent': 'android:com.ringapp',
-          Connection: 'close',
         },
       })
     } catch (e: any) {


### PR DESCRIPTION
Hi @dgreif,

This PR is an attempt to address the native fetch/undici issues that were causing http requests to stop.  I can provide a hugely detailed analysis of the failure, but, suffice it to say, I believe it has to do with how undici uses keepalive and pool connections.  There are quite a number of similar issues on the undici project page.

To work around this, the PR imports Agent from the undici package and creates a custom dispatcher with fewer max TCP connections and much longer keepalive.  This makes native NodeJS fetch behave more like browser fetch implementations as well as other http client libs like got (the actual values used are the same as Firefox).  This actually has a mostly positive impact for all users as it dramatically reduces the number of DNS lookups and TCP handshakes, since the HTTP connections are now long lived.

So far, I've had 4 users that were experiencing the issue test this patch, and success has been 100%.  I've tried to keep the patch as minimal as possible, with only the absolute minimum changes required.

In theory, it should even be possible to do this without pulling in undici dependency as it is possible to modify the global dispatcher, but I had some challenges with that and it felt very hackish.  However, if you believe this is better, I can pursue it.

Also, with a custom dispatcher it is possible to enable HTTP/2 via the `allowH2: true` option.  I did test this, however, H2 support in Undici has some pretty ciritcal bugs that regularly caused the NodeJS process to crash (issues are open, hopefully fixed in the next Undici release).  I'll monitor this for the future, but it doesn't seem stable for the time being.