### PR TITLE
Catch to prevent push-receiver crash on disconnect

### DIFF
--- a/.changeset/shy-needles-stare.md
+++ b/.changeset/shy-needles-stare.md
@@ -1,0 +1,6 @@
+---
+'homebridge-ring': patch
+'ring-client-api': patch
+---
+
+Handle errors when connecting to push notification service

--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -291,6 +291,17 @@ export class RingApi extends Subscribed {
         }
       }),
     )
+    pushReceiver.on('ON_DISCONNECT', () => {
+      pushReceiver.whenReady.catch((e) => {
+        logError(
+          'Connection to the push notification server has failed unexpectedly',
+        )
+        logError(
+          'If this happens repeatedly, verify connections to TCP/5228 are allowed and that DNS Adblock rules allow gtalk.google.com',
+        )
+        logError(e.message)
+      })
+    })
 
     try {
       await pushReceiver.connect()


### PR DESCRIPTION
This patch addresses an unhandled promise rejection that occurs in push-receiver 4.3.0.  This version of push-receiver introduced a new whenReady promise that consumers can use to know when the initial connection is ready.  However, it seems to have a bug when the socket connection fails as the code rejects the promise but has no catch for this rejection, thus creating an unhandled promise which leads to a process crash on modern NodeJS >15 which exit on unhandled promises by default.

It's possible to attach a catch handler outside of the library during first use, but the issue is that a new promise is created on every connection attempt, so, while that will catch the initial failure, subsequent retries are new promises without a catch.

This patch takes a different approach, instead of attaching the catch handler during creating, it instead listens for "ON_DISCONNECT" event, which happens just before the promise rejection, and immediately attaches a catch handler to the promise to prevent the unhandled rejection error.  It's a big of a hack, but seems to work reliably in testing until we can get upstream to fix the behavior (issue is already opened).