### PR TITLE
Add support for Battery Video Doorbell Pro

### DIFF
--- a/packages/ring-client-api/ring-types.ts
+++ b/packages/ring-client-api/ring-types.ts
@@ -100,6 +100,7 @@ export enum RingCameraKind {
   floodlight_pro = 'floodlight_pro',
   cocoa_camera = 'cocoa_camera', // appears to be used for all next gen stickup cams (wired/battery/solar)
   cocoa_doorbell = 'cocoa_doorbell',
+  cocoa_doorbell_v2 = 'cocoa_doorbell_v2',
   cocoa_doorbell_v3 = 'cocoa_doorbell_v3',
   cocoa_floodlight = 'cocoa_floodlight',
   cocoa_spotlight = 'cocoa_spotlight', // used for the Spotlight Cam Plus (potentially other Spotlight models)
@@ -137,6 +138,7 @@ export const RingCameraModel: { readonly [P in RingCameraKind]: string } = {
   floodlight_pro: 'Floodlight Pro',
   cocoa_camera: 'Stick Up Cam',
   cocoa_doorbell: 'Doorbell Gen 2',
+  cocoa_doorbell_v2: 'Battery Doorbell Plus',
   cocoa_doorbell_v3: 'Battery Doorbell Pro',
   cocoa_floodlight: 'Floodlight Cam Plus',
   cocoa_spotlight: 'Spotlight Cam Plus',

--- a/packages/ring-client-api/ring-types.ts
+++ b/packages/ring-client-api/ring-types.ts
@@ -100,6 +100,7 @@ export enum RingCameraKind {
   floodlight_pro = 'floodlight_pro',
   cocoa_camera = 'cocoa_camera', // appears to be used for all next gen stickup cams (wired/battery/solar)
   cocoa_doorbell = 'cocoa_doorbell',
+  cocoa_doorbell_v3 = 'cocoa_doorbell_v3',
   cocoa_floodlight = 'cocoa_floodlight',
   cocoa_spotlight = 'cocoa_spotlight', // used for the Spotlight Cam Plus (potentially other Spotlight models)
   stickup_cam_mini = 'stickup_cam_mini',
@@ -136,6 +137,7 @@ export const RingCameraModel: { readonly [P in RingCameraKind]: string } = {
   floodlight_pro: 'Floodlight Pro',
   cocoa_camera: 'Stick Up Cam',
   cocoa_doorbell: 'Doorbell Gen 2',
+  cocoa_doorbell_v3: 'Battery Doorbell Pro',
   cocoa_floodlight: 'Floodlight Cam Plus',
   cocoa_spotlight: 'Spotlight Cam Plus',
   stickup_cam_mini: 'Indoor Cam',


### PR DESCRIPTION
I recently purchased the Pro version of the Battery Video Doorbell - I am trying to get the actual device model to show up on the addons I use, Scrypted, Home Assistant (etc.) it makes the device look better rather it saying unknown model in Homekit 😋 

I presume just the v3 visual identifier needs to be added in the types - functionality is working 👍🏻 