### PR TITLE
Add KiddeSmokeCoAlarm to RingDeviceType

### DIFF
--- a/packages/ring-client-api/ring-types.ts
+++ b/packages/ring-client-api/ring-types.ts
@@ -45,6 +45,7 @@ export const RingDeviceType = {
   ThirdPartyGarageDoorOpener: 'third_party_gdo',
   IntercomHandsetAudio: 'intercom_handset_audio',
   WaterValve: 'valve.water',
+  KiddeSmokeCoAlarm: 'comp.bluejay.sensor_bluejay_wsc'
 } as const
 // eslint-disable-next-line no-redeclare
 export type RingDeviceType =

--- a/packages/ring-client-api/ring-types.ts
+++ b/packages/ring-client-api/ring-types.ts
@@ -45,7 +45,7 @@ export const RingDeviceType = {
   ThirdPartyGarageDoorOpener: 'third_party_gdo',
   IntercomHandsetAudio: 'intercom_handset_audio',
   WaterValve: 'valve.water',
-  KiddeSmokeCoAlarm: 'comp.bluejay.sensor_bluejay_wsc'
+  KiddeSmokeCoAlarm: 'comp.bluejay.sensor_bluejay_wsc',
 } as const
 // eslint-disable-next-line no-redeclare
 export type RingDeviceType =


### PR DESCRIPTION
Add support for new Kidde Smart Smoke and CO detector (https://ring.com/carbon-monoxide-smoke-detector-kidde)

Device type was discovered by listing devices in account and using the `deviceType`.