### PR TITLE
feat(homebridge-ring): expose Ring Alarm panel volume as a HomeKit slider (opt-in)

### DIFF
--- a/packages/homebridge-ring/config.ts
+++ b/packages/homebridge-ring/config.ts
@@ -23,6 +23,8 @@ export interface RingPlatformConfig extends RingApiOptions {
   onlyDeviceTypes?: string[]
   showPanicButtons?: boolean
   disableLogs?: boolean
+  exposeAlarmVolume?: boolean // Expose Base Station / Keypad volume as a HomeKit slider
+  volumeService?: 'lightbulb' | 'speaker' // (reserved for future) choose service type
 }
 
 export function updateHomebridgeConfig(

--- a/packages/homebridge-ring/ring-platform.ts
+++ b/packages/homebridge-ring/ring-platform.ts
@@ -51,6 +51,7 @@ import { UnknownZWaveSwitchSwitch } from './unknown-zwave-switch.ts'
 import { generateMacAddress } from './util.ts'
 import { Intercom } from './intercom.ts'
 import { Valve } from './valve.ts'
+import { VolumeAccessory } from './volume-accessory.ts'
 
 const ignoreHiddenDeviceTypes: string[] = [
   RingDeviceType.RingNetAdapter,
@@ -261,6 +262,29 @@ export class RingPlatform implements DynamicPlatformPlugin {
           onlyDeviceTypes = config.onlyDeviceTypes?.length
             ? config.onlyDeviceTypes
             : undefined
+
+        // add a VolumeAccessory when enabled and supported by the device
+        if (config.exposeAlarmVolume) {
+          devices.forEach((d) => {
+            const dev: any = d
+            const supportsVolume =
+              typeof dev?.setVolume === 'function' &&
+              typeof dev?.data?.volume === 'number'
+
+            if (supportsVolume) {
+              hapDevices.push({
+                deviceType: d.deviceType as string,
+                device: d as any,
+                isCamera: false,
+                id: d.id.toString() + 'volume',
+                name: `${d.name} Volume`,
+                AccessoryClass: VolumeAccessory as unknown as new (
+                  ...args: any[]
+                ) => BaseAccessory<any>,
+              })
+            }
+          })
+        }
 
         if (config.showPanicButtons && securityPanel) {
           hapDevices.push({

--- a/packages/homebridge-ring/volume-accessory.ts
+++ b/packages/homebridge-ring/volume-accessory.ts
@@ -1,0 +1,101 @@
+// packages/homebridge-ring/volume-accessory.ts
+import { logError, logInfo } from 'ring-client-api/util'
+import { hap } from './hap.ts'
+import { BaseDeviceAccessory } from './base-device-accessory.ts'
+
+/**
+ * Presents device volume as a HomeKit slider.
+ * Maps Brightness (0–100) <-> Ring volume (0.0–1.0).
+ * Attaches to any Ring device that:
+ *   - exposes data.volume (number)
+ *   - implements setVolume(number)
+ */
+export class VolumeAccessory extends BaseDeviceAccessory {
+  // BaseDeviceAccessory in this repo expects subclasses to expose these fields
+  public device: any
+  public accessory: any
+  public config: any
+
+  constructor(device: any, accessory: any, config: any) {
+    super() // Base class takes no constructor args in this codebase
+
+    this.device = device
+    this.accessory = accessory
+    this.config = config
+
+    // Create a Lightbulb so Home shows a visible slider (Brightness)
+    this.service = this.getService(hap.Service.Lightbulb)
+    this.init()
+  }
+
+  private service: any
+
+  private init() {
+    // "<Device Name> Volume"
+    this.service.setCharacteristic(
+      hap.Characteristic.Name,
+      `${this.device.name} Volume`,
+    )
+
+    // Required On characteristic (true if volume > 0)
+    this.service
+      .getCharacteristic(hap.Characteristic.On)
+      .onGet(() => this.currentVolume() > 0)
+      .onSet(async (value: unknown) => {
+        const on = Boolean(value)
+        if (!on) {
+          await this.setVolume(0)
+        }
+        // Turning on is handled by Brightness updates
+      })
+
+    // Brightness is the actual volume slider
+    this.service
+      .getCharacteristic(hap.Characteristic.Brightness)
+      .onGet(() => Math.round(this.currentVolume() * 100))
+      .onSet(async (value: unknown) => {
+        const pct = Math.max(0, Math.min(100, Number(value)))
+        await this.setVolume(pct / 100)
+      })
+
+    // Keep HomeKit in sync if device data changes
+    this.device.onData.subscribe((data: any) => {
+      const vol = typeof data?.volume === 'number' ? data.volume : undefined
+      if (typeof vol === 'number') {
+        this.service.updateCharacteristic(
+          hap.Characteristic.Brightness,
+          Math.round(vol * 100),
+        )
+        this.service.updateCharacteristic(hap.Characteristic.On, vol > 0)
+      }
+    })
+  }
+
+  private currentVolume(): number {
+    const vol = this.device?.data?.volume
+    return typeof vol === 'number' ? vol : 1
+  }
+
+  private async setVolume(vol: number) {
+    try {
+      const dev: any = this.device
+      if (typeof dev?.setVolume === 'function') {
+        await dev.setVolume(vol)
+        logInfo(`Set ${dev.name} volume to ${Math.round(vol * 100)}%`)
+      } else {
+        throw new Error(
+          `Device ${dev?.name ?? 'unknown'} does not support setVolume()`,
+        )
+      }
+    } catch (e) {
+      logError(e)
+      // Reflect last known device volume back to HomeKit
+      const back = this.currentVolume()
+      this.service.updateCharacteristic(
+        hap.Characteristic.Brightness,
+        Math.round(back * 100),
+      )
+      this.service.updateCharacteristic(hap.Characteristic.On, back > 0)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Expose the Ring Alarm **Base Station / Panel** volume to HomeKit as a visible slider. This is **opt-in** and coexists with the existing Speaker/Volume characteristic.

## Why
- Quick volume adjustments from the Home app (no need to open Ring).
- Enable scenes/automations (e.g., “Night” → quieter chimes).
- Keep defaults unchanged for users who don’t want the extra tile.

## Implementation
- **New accessory:** `VolumeAccessory`
  - Uses **Lightbulb** service so the slider is prominent.
  - Maps **Brightness (0–100)** ↔ **volume (0.0–1.0)**.
  - `On` = volume > 0; turning `Off` sets volume to 0.
  - Subscribes to `device.onData` to keep HomeKit in sync.
  - Gracefully handles devices without `setVolume()`.
- **Platform wiring:** in `ring-platform.ts`, when `exposeAlarmVolume` is true, attach `VolumeAccessory` for devices that have `data.volume` and `setVolume()`.
- **Config:** adds `exposeAlarmVolume?: boolean` (default `false`), and reserves `volumeService?: 'lightbulb' | 'speaker'` for future use.
- **NodeNext-friendly imports:** use explicit `.ts` extensions.

## Behavior
- **Default:** no changes unless `exposeAlarmVolume` is enabled.
- When enabled, a new accessory like “\<Panel Name\> Volume” appears with a slider.
- Slider changes affect the device immediately; external volume changes reflect back in HomeKit.

## Config example
```json
{
  "platform": "Ring",
  "refreshToken": "<your-token>",
  "exposeAlarmVolume": true
}
