### PR TITLE
Update locationMode using security-panel.mode-switched impulse

### DIFF
--- a/packages/ring-client-api/location.ts
+++ b/packages/ring-client-api/location.ts
@@ -163,6 +163,30 @@ export class Location extends Subscribed {
       // start listening for devices immediately
       this.onDevices.subscribe(),
 
+      this.onDataUpdate.subscribe((message) => {
+        const impulses = message.body?.[0]?.impulse?.v1 || []
+        for (const impulse of impulses) {
+          if (impulse.impulseType.startsWith('security-panel.mode-switched.')) {
+            const rawType = impulse.impulseType.split('.').pop()
+            let finalMode: LocationMode
+
+            switch (rawType) {
+              case 'all':
+                finalMode = 'away'
+                break
+              case 'some':
+                finalMode = 'home'
+                break
+              case 'none':
+              default:
+                finalMode = 'disarmed'
+            }
+
+            this.onLocationMode.next(finalMode)
+          }
+        }
+      }),
+
       // watch for sessions to come online
       this.onSessionInfo.subscribe((sessions) => {
         sessions.forEach(({ connectionStatus, assetUuid }) => {


### PR DESCRIPTION
I noticed that locationMode push updates do not work for my Ring Alarm system. I was able to fix it by listening to `security-panel.mode-switched` impulses. I don't know if there are other things to consider or change, but it works perfectly for me and I receive immediate locationMode changes via push again.