### PR TITLE
fix: redact 2FA code from homebridge-ui server log

### DIFF
--- a/.changeset/redact-2fa-code-from-ui-log.md
+++ b/.changeset/redact-2fa-code-from-ui-log.md
@@ -1,0 +1,5 @@
+---
+"homebridge-ring": patch
+---
+
+Redact the 2FA code from the homebridge-ui server log on token exchange. Codes are short-lived and single-use, but logs are frequently pasted into bug reports, so removing the value from the log is a small defensive improvement.

--- a/packages/homebridge-ring/homebridge-ui/server.ts
+++ b/packages/homebridge-ring/homebridge-ui/server.ts
@@ -59,7 +59,7 @@ class PluginUiServer extends HomebridgePluginUiServer {
   generateToken = async ({ email, password, code }: TokenRequest) => {
     // use the existing restClient to avoid sending a token again
     this.restClient = this.restClient || new RingRestClient({ email, password })
-    console.log(`Getting token for ${email} with code ${code}`)
+    console.log(`Getting token for ${email}`)
 
     try {
       const authResponse = await this.restClient.getAuth(code)


### PR DESCRIPTION
## Summary
The homebridge-ui plugin server logs the user's 2FA code in plaintext at [`packages/homebridge-ring/homebridge-ui/server.ts:62`](https://github.com/dgreif/ring/blob/main/packages/homebridge-ring/homebridge-ui/server.ts#L62) when exchanging it for a refresh token:

```ts
console.log(`Getting token for ${email} with code ${code}`)
```

Ring's 2FA codes are short-lived (~10 min) and single-use, so the practical risk is bounded — but homebridge logs are frequently pasted into bug reports, GitHub issues, and Discord screenshots. Anyone watching the log in that window could replay the code before it expires.

This PR drops `with code ${code}` from the log statement. The email is kept so the "we're at the token-exchange step for this user" signal is preserved for debugging.

## Changes
- One-line edit in `homebridge-ring/homebridge-ui/server.ts`
- Changeset added (patch bump on `homebridge-ring`)

## Test plan
- [x] `npx turbo run lint test --filter=homebridge-ring --filter=ring-client-api` — all 18 tests pass, lint clean
- [x] Manual review: `code` is still destructured and passed to `getAuth(code)` on the following line, so the unused-var lint rule isn't triggered and behavior is unchanged