### PR TITLE
Update ring-client-api to use v3 location/devices REST endpoints

### DIFF
--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -1,5 +1,10 @@
 import type { RefreshTokenAuth, SessionOptions } from './rest-client.ts'
-import { clientApi, deviceApi, RingRestClient } from './rest-client.ts'
+import {
+  clientApi,
+  deviceInfoApi,
+  locationInfoApi,
+  RingRestClient,
+} from './rest-client.ts'
 import { Location } from './location.ts'
 import type {
   BaseStation,
@@ -14,7 +19,12 @@ import type {
   UnknownDevice,
   UserLocation,
 } from './ring-types.ts'
-import { PushNotificationAction, RingDeviceType } from './ring-types.ts'
+import {
+  ChimeModel,
+  PushNotificationAction,
+  RingCameraKind,
+  RingDeviceType,
+} from './ring-types.ts'
 import type { AnyCameraData } from './ring-camera.ts'
 import { RingCamera } from './ring-camera.ts'
 import { RingChime } from './ring-chime.ts'
@@ -37,6 +47,17 @@ import { Subscribed } from './subscribed.ts'
 import { PushReceiver } from '@eneris/push-receiver'
 import { RingIntercom } from './ring-intercom.ts'
 import JSONbig from 'json-bigint'
+
+const doorbellKinds: Set<string> = new Set(
+  Object.values(RingCameraKind).filter(
+    (k) =>
+      k.startsWith('doorbot') ||
+      k.startsWith('doorbell') ||
+      k.startsWith('lpd_') ||
+      k.startsWith('jbox_') ||
+      k.startsWith('cocoa_doorbell'),
+  ),
+)
 
 export interface RingApiOptions extends SessionOptions {
   locationIds?: string[]
@@ -82,50 +103,59 @@ export class RingApi extends Subscribed {
   }
 
   async fetchRingDevices() {
-    const {
-        doorbots,
-        chimes,
-        authorized_doorbots: authorizedDoorbots,
-        stickup_cams: stickupCams,
-        base_stations: baseStations,
-        beams_bridges: beamBridges,
-        other: otherDevices,
-      } = await this.restClient.request<{
-        doorbots: CameraData[]
-        chimes: ChimeData[]
-        authorized_doorbots: CameraData[]
-        stickup_cams: CameraData[]
-        base_stations: BaseStation[]
-        beams_bridges: BeamBridge[]
-        other: (
+    const { devices } = await this.restClient.request<{
+        devices: (
+          | CameraData
+          | ChimeData
+          | BaseStation
+          | BeamBridge
           | IntercomHandsetData
           | OnvifCameraData
           | ThirdPartyGarageDoorOpener
           | UnknownDevice
         )[]
-      }>({ url: clientApi('ring_devices') }),
+      }>({ url: deviceInfoApi('devices') }),
+      doorbots = [] as CameraData[],
+      authorizedDoorbots = [] as CameraData[],
+      stickupCams = [] as CameraData[],
+      chimes = [] as ChimeData[],
+      baseStations = [] as BaseStation[],
+      beamBridges = [] as BeamBridge[],
       onvifCameras = [] as OnvifCameraData[],
       intercoms = [] as IntercomHandsetData[],
       thirdPartyGarageDoorOpeners = [] as ThirdPartyGarageDoorOpener[],
       unknownDevices = [] as UnknownDevice[]
 
-    otherDevices.forEach((device) => {
-      switch (device.kind) {
-        case RingDeviceType.OnvifCamera:
-          onvifCameras.push(device as OnvifCameraData)
-          break
-        case RingDeviceType.IntercomHandsetVideo:
-        case RingDeviceType.IntercomHandsetAudio:
-          intercoms.push(device as IntercomHandsetData)
-          break
-        case RingDeviceType.ThirdPartyGarageDoorOpener:
-          thirdPartyGarageDoorOpeners.push(device as ThirdPartyGarageDoorOpener)
-          break
-        default:
-          unknownDevices.push(device)
-          break
+    for (const device of devices) {
+      const kind = device.kind as string
+
+      if (doorbellKinds.has(kind)) {
+        if ((device as CameraData).owned === false) {
+          authorizedDoorbots.push(device as CameraData)
+        } else {
+          doorbots.push(device as CameraData)
+        }
+      } else if (kind in ChimeModel) {
+        chimes.push(device as ChimeData)
+      } else if (kind.startsWith('base_station')) {
+        baseStations.push(device as BaseStation)
+      } else if (kind.startsWith('beams_bridge')) {
+        beamBridges.push(device as BeamBridge)
+      } else if (kind === RingDeviceType.OnvifCamera) {
+        onvifCameras.push(device as OnvifCameraData)
+      } else if (
+        kind === RingDeviceType.IntercomHandsetAudio ||
+        kind === RingDeviceType.IntercomHandsetVideo
+      ) {
+        intercoms.push(device as IntercomHandsetData)
+      } else if (kind === RingDeviceType.ThirdPartyGarageDoorOpener) {
+        thirdPartyGarageDoorOpeners.push(device as ThirdPartyGarageDoorOpener)
+      } else if (kind in RingCameraKind) {
+        stickupCams.push(device as CameraData)
+      } else {
+        unknownDevices.push(device as UnknownDevice)
       }
-    })
+    }
 
     return {
       doorbots,
@@ -397,7 +427,7 @@ export class RingApi extends Subscribed {
   async fetchRawLocations() {
     const { user_locations: rawLocations } = await this.restClient.request<{
       user_locations: UserLocation[]
-    }>({ url: deviceApi('locations') })
+    }>({ url: locationInfoApi('locations') })
 
     if (!rawLocations) {
       throw new Error(

--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -103,18 +103,22 @@ export class RingApi extends Subscribed {
   }
 
   async fetchRingDevices() {
-    const { devices } = await this.restClient.request<{
-        devices: (
-          | CameraData
-          | ChimeData
-          | BaseStation
-          | BeamBridge
-          | IntercomHandsetData
-          | OnvifCameraData
-          | ThirdPartyGarageDoorOpener
-          | UnknownDevice
-        )[]
-      }>({ url: deviceInfoApi('devices') }),
+    const { devices, device_operation_sets: deviceOperationSets } =
+        await this.restClient.request<{
+          devices: (
+            | CameraData
+            | ChimeData
+            | BaseStation
+            | BeamBridge
+            | IntercomHandsetData
+            | OnvifCameraData
+            | ThirdPartyGarageDoorOpener
+            | UnknownDevice
+          )[]
+          device_operation_sets?: {
+            [operationSet: string]: { [operation: string]: object }
+          }
+        }>({ url: deviceInfoApi('devices') }),
       doorbots = [] as CameraData[],
       authorizedDoorbots = [] as CameraData[],
       stickupCams = [] as CameraData[],
@@ -127,7 +131,18 @@ export class RingApi extends Subscribed {
       unknownDevices = [] as UnknownDevice[]
 
     for (const device of devices) {
-      const kind = device.kind as string
+      // Resolve the operation set the device was tagged with into the list of
+      // operations this account may perform on it.  Devices shared by another
+      // account can be limited to a subset (no device_alerts_manage, for
+      // example, which is required to subscribe to ding/motion notifications)
+      const kind = device.kind as string,
+        operationSet = (device as CameraData).operation_set
+
+      if (operationSet && deviceOperationSets?.[operationSet]) {
+        ;(device as CameraData).operations = Object.keys(
+          deviceOperationSets[operationSet],
+        )
+      }
 
       if (doorbellKinds.has(kind)) {
         if ((device as CameraData).owned === false) {
@@ -312,7 +327,7 @@ export class RingApi extends Subscribed {
               device: {
                 metadata: {
                   ...this.restClient.baseSessionMetadata,
-                  pn_dict_version: '2.0.0',
+                  pn_dict_version: '2.4.0',
                   pn_service: 'fcm',
                 },
                 os: 'android',

--- a/packages/ring-client-api/location.ts
+++ b/packages/ring-client-api/location.ts
@@ -28,7 +28,6 @@ import type {
   SocketIoMessage,
   TicketAsset,
   UserLocation,
-  CameraEventResponse,
   CameraEventOptions,
   HistoryOptions,
   RingDeviceHistoryEvent,
@@ -46,9 +45,9 @@ import {
   isWebSocketSupportedAsset,
 } from './ring-types.ts'
 import type { RingRestClient } from './rest-client.ts'
-import { appApi, clientApi } from './rest-client.ts'
+import { appApi } from './rest-client.ts'
 import type { RingCamera } from './ring-camera.ts'
-import { getSearchQueryString } from './ring-camera.ts'
+import { getEventHistory, getSearchQueryString } from './ring-camera.ts'
 import type { RingChime } from './ring-chime.ts'
 import { RingDevice } from './ring-device.ts'
 import type { RingIntercom } from './ring-intercom.ts'
@@ -480,11 +479,11 @@ export class Location extends Subscribed {
   }
 
   getCameraEvents(options: CameraEventOptions = {}) {
-    return this.restClient.request<CameraEventResponse>({
-      url: clientApi(
-        `locations/${this.id}/events${getSearchQueryString(options)}`,
-      ),
-    })
+    return getEventHistory(
+      this.restClient,
+      this.cameras.map((camera) => camera.id),
+      options,
+    )
   }
 
   getAccountMonitoringStatus() {

--- a/packages/ring-client-api/rest-client.ts
+++ b/packages/ring-client-api/rest-client.ts
@@ -46,6 +46,8 @@ const fetchAgent = new Agent({
   deviceApiBaseUrl = 'https://api.ring.com/devices/v1/',
   commandsApiBaseUrl = 'https://api.ring.com/commands/v1/',
   appApiBaseUrl = 'https://prd-api-us.prd.rings.solutions/api/v1/',
+  deviceInfoApiBaseUrl = 'https://api.ring.com/device_info/v3/',
+  locationInfoApiBaseUrl = 'https://api.ring.com/location_info/v3/',
   apiVersion = 11
 
 export function clientApi(path: string) {
@@ -62,6 +64,14 @@ export function commandsApi(path: string) {
 
 export function appApi(path: string) {
   return appApiBaseUrl + path
+}
+
+export function deviceInfoApi(path: string) {
+  return deviceInfoApiBaseUrl + path
+}
+
+export function locationInfoApi(path: string) {
+  return locationInfoApiBaseUrl + path
 }
 
 export interface ExtendedResponse {

--- a/packages/ring-client-api/rest-client.ts
+++ b/packages/ring-client-api/rest-client.ts
@@ -48,6 +48,8 @@ const fetchAgent = new Agent({
   appApiBaseUrl = 'https://prd-api-us.prd.rings.solutions/api/v1/',
   deviceInfoApiBaseUrl = 'https://api.ring.com/device_info/v3/',
   locationInfoApiBaseUrl = 'https://api.ring.com/location_info/v3/',
+  evmApiBaseUrl = 'https://api.ring.com/evm/v3/',
+  oauthBaseUrl = 'https://oauth.ring.com',
   apiVersion = 11
 
 export function clientApi(path: string) {
@@ -72,6 +74,10 @@ export function deviceInfoApi(path: string) {
 
 export function locationInfoApi(path: string) {
   return locationInfoApiBaseUrl + path
+}
+
+export function evmApi(path: string) {
+  return evmApiBaseUrl + path
 }
 
 export interface ExtendedResponse {

--- a/packages/ring-client-api/ring-camera.ts
+++ b/packages/ring-client-api/ring-camera.ts
@@ -5,6 +5,7 @@ import {
   type CameraDeviceSettingsData,
   type CameraEventOptions,
   type CameraEventResponse,
+  type EventHistoryResponse,
   type CameraHealth,
   DoorbellType,
   type HistoryOptions,
@@ -17,7 +18,13 @@ import {
   type PushNotification,
 } from './ring-types.ts'
 import type { RingRestClient } from './rest-client.ts'
-import { appApi, clientApi, deviceApi } from './rest-client.ts'
+import {
+  appApi,
+  clientApi,
+  deviceApi,
+  deviceInfoApi,
+  evmApi,
+} from './rest-client.ts'
 import { BehaviorSubject, firstValueFrom, ReplaySubject, Subject } from 'rxjs'
 import {
   distinctUntilChanged,
@@ -93,6 +100,98 @@ export function getBatteryLevel(
   }
 
   return Math.min(...levels)
+}
+
+// Matches the timestamp format used by the legacy health endpoints
+// (ex. 2026-08-25T23:01:14+00:00)
+function formatHealthUpdatedAt(lastUpdateTime: number | undefined) {
+  const updatedAt = lastUpdateTime
+    ? new Date(lastUpdateTime * 1000)
+    : new Date()
+
+  return updatedAt.toISOString().replace(/\.\d{3}Z$/, '+00:00')
+}
+
+// The legacy clients_api health endpoint only works for devices owned by the
+// authenticated account, returning a 404 for shared devices, so health is
+// instead derived from the health data included with the device data
+export function mapCameraHealth(
+  id: number,
+  health: Partial<CameraData['health']> | undefined,
+): CameraHealth | undefined {
+  if (!health || !Object.keys(health).length) {
+    // Some device types (chimes, for example) have no health data in the
+    // device_info api and must continue to use the legacy health endpoint
+    return undefined
+  }
+
+  const { rssi, rssi_category: rssiCategory, ...rest } = health
+
+  return {
+    id,
+    wifi_name: rest.wifi_name,
+    battery_percentage: rest.battery_percentage,
+    battery_percentage_category: rest.battery_percentage_category ?? 'unknown',
+    battery_voltage: rest.battery_voltage ?? null,
+    battery_voltage_category: rest.battery_voltage_category ?? null,
+    latest_signal_strength: rssi ?? null,
+    latest_signal_category: rssiCategory ?? 'NA',
+    average_signal_strength: rssi ?? null,
+    average_signal_category: rssiCategory ?? 'NA',
+    firmware: rest.firmware_version_status ?? rest.firmware_version ?? '',
+    updated_at: formatHealthUpdatedAt(rest.last_update_time),
+    wifi_is_ring_network: rest.wifi_is_ring_network,
+    packet_loss_category: rest.packet_loss_category ?? 'NA',
+    packet_loss_strength: rest.packet_loss ?? null,
+    network_connection: rest.network_connection_value,
+    transformer_voltage: rest.transformer_voltage,
+    transformer_voltage_category: rest.transformer_voltage_category,
+    ext_power_state: rest.ext_power_state,
+  }
+}
+
+// The evm history api replaces the legacy clients_api events endpoints, which
+// return a 404 for devices that are shared with, but not owned by, this account
+export function getEventHistory(
+  restClient: RingRestClient,
+  sourceIds: (string | number)[],
+  options: CameraEventOptions = {},
+) {
+  const { limit, kind, state, favorites, olderThanId, pagination_key } =
+      options,
+    queryString = Object.entries({
+      source_ids: sourceIds.join(','),
+      limit,
+      event_types: kind,
+      state,
+      favorites,
+      pagination_key: pagination_key ?? olderThanId,
+    })
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => `${key}=${encodeURIComponent(String(value))}`)
+      .join('&')
+
+  return restClient
+    .request<EventHistoryResponse>({
+      url: evmApi(`history/devices?${queryString}`),
+    })
+    .then(
+      ({ events, pagination_key: paginationKey }): CameraEventResponse => ({
+        events: (events ?? []).map((event) => ({
+          ...event,
+          created_at: event.start_time,
+          cv_properties: event.cv,
+          ding_id: Number(event.event_id),
+          ding_id_str: event.event_id,
+          doorbot_id: Number(event.source_id),
+          favorite: event.is_favorite,
+          kind: event.event_type,
+          recorded: event.recording_status === 'ready',
+        })),
+        meta: { pagination_key: paginationKey },
+        pagination_key: paginationKey,
+      }),
+    )
 }
 
 export function getSearchQueryString(
@@ -219,6 +318,14 @@ export class RingCamera extends Subscribed {
       this.restClient.onSession
         .pipe(startWith(undefined), throttleTime(1000)) // Force this to run immediately, but don't double run if a session is created due to these api calls
         .subscribe(() => {
+          if (!this.canSubscribeToNotifications) {
+            logDebug(
+              initialData.description +
+                ' is shared with this account without the device_alerts_manage operation, so it cannot be subscribed to ding/motion notifications',
+            )
+            return
+          }
+
           this.subscribeToDingEvents().catch((e) => {
             logError(
               'Failed to subscribe ' +
@@ -307,6 +414,22 @@ export class RingCamera extends Subscribed {
 
   get isOffline() {
     return this.data.alerts.connection === 'offline'
+  }
+
+  // Operations this account is allowed to perform on the device.  Devices
+  // shared by another account may allow only a subset, and the api answers
+  // with a 404 for anything outside of it.  Undefined when the api did not
+  // report an operation set, in which case no operation should be assumed
+  // unavailable.
+  canPerformOperation(operation: string) {
+    const { operations } = this.data as CameraData
+
+    return operations ? operations.includes(operation) : undefined
+  }
+
+  // device_alerts_manage is required to subscribe to ding/motion notifications
+  get canSubscribeToNotifications() {
+    return this.canPerformOperation('device_alerts_manage') !== false
   }
 
   get isRingEdgeEnabled() {
@@ -407,13 +530,13 @@ export class RingCamera extends Subscribed {
   }
 
   async getHealth() {
-    const response = await this.restClient.request<{
-      device_health: CameraHealth
+    const { device } = await this.restClient.request<{
+      device: { health?: Partial<CameraData['health']> }
     }>({
-      url: this.doorbotUrl('health'),
+      url: deviceInfoApi(`devices/${this.id}`),
     })
 
-    return response.device_health
+    return mapCameraHealth(this.id, device.health)
   }
 
   private async createStreamingConnection(options: StreamingConnectionOptions) {
@@ -476,13 +599,7 @@ export class RingCamera extends Subscribed {
   }
 
   getEvents(options: CameraEventOptions = {}) {
-    return this.restClient.request<CameraEventResponse>({
-      url: clientApi(
-        `locations/${this.data.location_id}/devices/${
-          this.id
-        }/events${getSearchQueryString(options)}`,
-      ),
-    })
+    return getEventHistory(this.restClient, [this.id], options)
   }
 
   videoSearch(

--- a/packages/ring-client-api/ring-intercom.ts
+++ b/packages/ring-client-api/ring-intercom.ts
@@ -1,10 +1,15 @@
-import type { IntercomHandsetData, PushNotification } from './ring-types.ts'
+import type {
+  CameraData,
+  CameraHealth,
+  IntercomHandsetData,
+  PushNotification,
+} from './ring-types.ts'
 import { PushNotificationAction } from './ring-types.ts'
 import type { RingRestClient } from './rest-client.ts'
-import { clientApi, commandsApi } from './rest-client.ts'
+import { clientApi, commandsApi, deviceInfoApi } from './rest-client.ts'
 import { BehaviorSubject, Subject } from 'rxjs'
 import { distinctUntilChanged, map } from 'rxjs/operators'
-import { getBatteryLevel } from './ring-camera.ts'
+import { getBatteryLevel, mapCameraHealth } from './ring-camera.ts'
 import { logError } from './util.ts'
 
 export class RingIntercom {
@@ -84,6 +89,29 @@ export class RingIntercom {
 
   private doorbotUrl(path = '') {
     return clientApi(`doorbots/${this.id}/${path}`)
+  }
+
+  async getHealth() {
+    const { device } = await this.restClient.request<{
+        device: { health?: Partial<CameraData['health']> }
+      }>({
+        url: deviceInfoApi(`devices/${this.id}`),
+      }),
+      health = mapCameraHealth(this.id, device.health)
+
+    if (health) {
+      return health
+    }
+
+    // Fall back to the legacy health endpoint, which does not work for shared
+    // devices, but does still return data which the device_info api may not
+    const response = await this.restClient.request<{
+      device_health: CameraHealth
+    }>({
+      url: this.doorbotUrl('health'),
+    })
+
+    return response.device_health
   }
 
   subscribeToDingEvents() {

--- a/packages/ring-client-api/ring-types.ts
+++ b/packages/ring-client-api/ring-types.ts
@@ -429,13 +429,21 @@ export interface LocationAddress {
 export interface UserLocation {
   address: LocationAddress
   created_at: string
-  geo_coordinates: { latitude: string; longitude: string }
+  geo_coordinates: { latitude: string | number; longitude: string | number }
   geo_service_verified: 'address_only' | string
   location_id: string
   name: string
   owner_id: number
   updated_at: string
   user_verified: boolean
+  is_owner?: boolean
+  operation_set?: string
+  entitlements?: {
+    business_command_center?: boolean
+    business_role_management?: boolean
+    vm_virtual_security_guard?: boolean
+  }
+  location_resource_id?: string
 }
 
 export interface TicketAsset {

--- a/packages/ring-client-api/ring-types.ts
+++ b/packages/ring-client-api/ring-types.ts
@@ -487,6 +487,12 @@ export interface BaseCameraData {
   motion_snooze: null | { scheduled: boolean }
   night_mode_status: 'unknown' | 'true' | 'false'
   owned: boolean
+  // The operation set this device is tagged with ('owner' for owned devices, a
+  // numeric code for devices shared by another account)
+  operation_set?: string
+  // Resolved by this client from the device_operation_sets map returned
+  // alongside the device list, not a field returned per device by the api
+  operations?: string[]
   ring_net_id: null
 
   settings: {
@@ -578,6 +584,7 @@ export interface BaseCameraData {
     packet_loss_category: 'good' | string
     rssi: number
     battery_voltage: number
+    wifi_name?: string
     wifi_is_ring_network: boolean
     supported_rpc_commands: string[]
     ota_status: 'successful' | string
@@ -599,6 +606,8 @@ export interface BaseCameraData {
     battery_save: boolean
     firmware_version_status: 'Up to Date'
     tx_rate: number
+    transformer_voltage?: number
+    transformer_voltage_category?: 'good' | string
     ptz_connected?: 'penguin'
   }
 }
@@ -919,9 +928,27 @@ export interface ChimeHealth {
   packet_loss_strength: number
 }
 
-export interface CameraHealth extends ChimeHealth {
+// Legacy shape of the camera health data, which is now derived from the
+// health data included in the device_info api responses
+export interface CameraHealth {
+  id: number
+  wifi_name?: string | null
+  battery_percentage?: number | null
+  battery_percentage_category: HealthCategory
+  battery_voltage: number | null
+  battery_voltage_category: HealthCategory
+  latest_signal_strength: number | null
+  latest_signal_category: HealthCategory
+  average_signal_strength: number | null
+  average_signal_category: HealthCategory
+  firmware: Firmware
+  updated_at: string
+  wifi_is_ring_network?: boolean
+  packet_loss_category: HealthCategory
+  packet_loss_strength: number | null
+  network_connection?: 'wifi' | 'ethernet' | string
   transformer_voltage?: number
-  transformer_voltage_category?: 'good'
+  transformer_voltage_category?: HealthCategory
   ext_power_state?: number
 }
 
@@ -937,21 +964,74 @@ export type DingKind =
   | 'OFFLINE_FOOTAGE'
   | 'OFFLINE_MOTION'
 
-export interface CameraEvent {
-  created_at: string
-  cv_properties: {
-    detection_type: null | any
-    person_detected: null | any
-    stream_broken: null | any
+export interface CameraEventCvProperties {
+  detection_type: null | any
+  detection_types?:
+    | { detection_type: string; verified_timestamps: number[] }[]
+    | null
+  person_detected: null | any
+  stream_broken: null | any
+  security_alerts?: any
+  full_description?: string | null
+  short_description?: string | null
+}
+
+export interface CameraEventMedia {
+  url: string | null
+  start_time: string
+  end_time: string | null
+  file_type: 'VIDEO' | 'THUMBNAIL' | string
+  file_family?: string
+  is_e2ee: boolean
+  playback_duration?: number | null
+  custom_metadata?: any
+}
+
+// Event as returned by the evm history api
+export interface EventHistoryEvent {
+  source_id: string
+  event_id: string
+  start_time: string
+  end_time: string | null
+  event_type: DingKind | string
+  duration_ms?: number | null
+  session_duration?: number | null
+  state: 'timed_out' | 'completed' | string
+  had_subscription: boolean
+  is_favorite: boolean
+  recording_status: 'ready' | 'audio_ready' | string
+  cv: CameraEventCvProperties
+  properties?: {
+    is_alexa?: boolean
+    is_sidewalk?: boolean
+    is_autoreply?: boolean
+    stark_reviewed?: boolean
   }
+  updated_at?: string
+  visualizations?: {
+    cloud_media_visualization?: { media: CameraEventMedia[] } | null
+  } | null
+  device?: { id: number; description: string; type: string } | null
+  owner_id?: string | null
+}
+
+export interface EventHistoryResponse {
+  events: EventHistoryEvent[]
+  feed?: { id: string; type: string }[]
+  pagination_key?: string
+}
+
+// An evm history event, with the field names used by the legacy clients_api
+// events endpoints retained for backwards compatibility
+export interface CameraEvent extends EventHistoryEvent {
+  created_at: string
+  cv_properties: CameraEventCvProperties
   ding_id: number
   ding_id_str: string
   doorbot_id: number
   favorite: boolean
-  kind: DingKind
-  recorded: false
-  recording_status: 'ready' | 'audio_ready'
-  state: 'timed_out' | 'completed'
+  kind: DingKind | string
+  recorded: boolean
 }
 
 // timed_out + ding === Missed Ring
@@ -959,7 +1039,8 @@ export interface CameraEvent {
 
 export interface CameraEventResponse {
   events: CameraEvent[]
-  meta: { pagination_key: string }
+  meta: { pagination_key?: string }
+  pagination_key?: string
 }
 
 export interface CameraEventOptions {


### PR DESCRIPTION
This is the first in a series of PRs to bring ring-client-api on par with modern Ring API specs.  While I have tested these changes with ring-mqtt, these are changes in core functions that have remained largely unchaged for many years so this PR has more risk than many.

This PR updates the Ring client library to use the latest REST API endpoints for location and device discovery.  I've tried to keep the changes to the minimum and not break anything for API consumers.  The new locations endpoint provides roughly the same information and format of the previous, however, the new devices endpoint is quite different.

I've tested this with my account which has the following devices:

Doorbell Pro
Floodlight (1st gen)
Stickup Cams (various)
Floodlight Pro
Chime
Alarm (1st gen) with many devices

The most likely risks to the change are around shared locations as there are some differences in how discovery of location devices works, but I don't have a shared account to test.

**Important Note:**  This code was written 99% by Claude Code.  I have manually reviewed the code, applying a few minor tweaks, mostly for style, and also performed manual functional testing.