### PR TITLE
Implement OAuth 2.0 + PKCE authentication flow

### DIFF
--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -1,5 +1,10 @@
 import type { RefreshTokenAuth, SessionOptions } from './rest-client.ts'
-import { clientApi, deviceApi, RingRestClient } from './rest-client.ts'
+import {
+  clientApi,
+  deviceInfoApi,
+  locationInfoApi,
+  RingRestClient,
+} from './rest-client.ts'
 import { Location } from './location.ts'
 import type {
   BaseStation,
@@ -14,7 +19,12 @@ import type {
   UnknownDevice,
   UserLocation,
 } from './ring-types.ts'
-import { PushNotificationAction, RingDeviceType } from './ring-types.ts'
+import {
+  ChimeModel,
+  PushNotificationAction,
+  RingCameraKind,
+  RingDeviceType,
+} from './ring-types.ts'
 import type { AnyCameraData } from './ring-camera.ts'
 import { RingCamera } from './ring-camera.ts'
 import { RingChime } from './ring-chime.ts'
@@ -37,6 +47,17 @@ import { Subscribed } from './subscribed.ts'
 import { PushReceiver } from '@eneris/push-receiver'
 import { RingIntercom } from './ring-intercom.ts'
 import JSONbig from 'json-bigint'
+
+const doorbellKinds: Set<string> = new Set(
+  Object.values(RingCameraKind).filter(
+    (k) =>
+      k.startsWith('doorbot') ||
+      k.startsWith('doorbell') ||
+      k.startsWith('lpd_') ||
+      k.startsWith('jbox_') ||
+      k.startsWith('cocoa_doorbell'),
+  ),
+)
 
 export interface RingApiOptions extends SessionOptions {
   locationIds?: string[]
@@ -82,50 +103,59 @@ export class RingApi extends Subscribed {
   }
 
   async fetchRingDevices() {
-    const {
-        doorbots,
-        chimes,
-        authorized_doorbots: authorizedDoorbots,
-        stickup_cams: stickupCams,
-        base_stations: baseStations,
-        beams_bridges: beamBridges,
-        other: otherDevices,
-      } = await this.restClient.request<{
-        doorbots: CameraData[]
-        chimes: ChimeData[]
-        authorized_doorbots: CameraData[]
-        stickup_cams: CameraData[]
-        base_stations: BaseStation[]
-        beams_bridges: BeamBridge[]
-        other: (
+    const { devices } = await this.restClient.request<{
+        devices: (
+          | CameraData
+          | ChimeData
+          | BaseStation
+          | BeamBridge
           | IntercomHandsetData
           | OnvifCameraData
           | ThirdPartyGarageDoorOpener
           | UnknownDevice
         )[]
-      }>({ url: clientApi('ring_devices') }),
+      }>({ url: deviceInfoApi('devices') }),
+      doorbots = [] as CameraData[],
+      authorizedDoorbots = [] as CameraData[],
+      stickupCams = [] as CameraData[],
+      chimes = [] as ChimeData[],
+      baseStations = [] as BaseStation[],
+      beamBridges = [] as BeamBridge[],
       onvifCameras = [] as OnvifCameraData[],
       intercoms = [] as IntercomHandsetData[],
       thirdPartyGarageDoorOpeners = [] as ThirdPartyGarageDoorOpener[],
       unknownDevices = [] as UnknownDevice[]
 
-    otherDevices.forEach((device) => {
-      switch (device.kind) {
-        case RingDeviceType.OnvifCamera:
-          onvifCameras.push(device as OnvifCameraData)
-          break
-        case RingDeviceType.IntercomHandsetVideo:
-        case RingDeviceType.IntercomHandsetAudio:
-          intercoms.push(device as IntercomHandsetData)
-          break
-        case RingDeviceType.ThirdPartyGarageDoorOpener:
-          thirdPartyGarageDoorOpeners.push(device as ThirdPartyGarageDoorOpener)
-          break
-        default:
-          unknownDevices.push(device)
-          break
+    for (const device of devices) {
+      const kind = device.kind as string
+
+      if (doorbellKinds.has(kind)) {
+        if ((device as CameraData).owned === false) {
+          authorizedDoorbots.push(device as CameraData)
+        } else {
+          doorbots.push(device as CameraData)
+        }
+      } else if (kind in ChimeModel) {
+        chimes.push(device as ChimeData)
+      } else if (kind.startsWith('base_station')) {
+        baseStations.push(device as BaseStation)
+      } else if (kind.startsWith('beams_bridge')) {
+        beamBridges.push(device as BeamBridge)
+      } else if (kind === RingDeviceType.OnvifCamera) {
+        onvifCameras.push(device as OnvifCameraData)
+      } else if (
+        kind === RingDeviceType.IntercomHandsetAudio ||
+        kind === RingDeviceType.IntercomHandsetVideo
+      ) {
+        intercoms.push(device as IntercomHandsetData)
+      } else if (kind === RingDeviceType.ThirdPartyGarageDoorOpener) {
+        thirdPartyGarageDoorOpeners.push(device as ThirdPartyGarageDoorOpener)
+      } else if (kind in RingCameraKind) {
+        stickupCams.push(device as CameraData)
+      } else {
+        unknownDevices.push(device as UnknownDevice)
       }
-    })
+    }
 
     return {
       doorbots,
@@ -397,7 +427,7 @@ export class RingApi extends Subscribed {
   async fetchRawLocations() {
     const { user_locations: rawLocations } = await this.restClient.request<{
       user_locations: UserLocation[]
-    }>({ url: deviceApi('locations') })
+    }>({ url: locationInfoApi('locations') })
 
     if (!rawLocations) {
       throw new Error(

--- a/packages/ring-client-api/rest-client.ts
+++ b/packages/ring-client-api/rest-client.ts
@@ -46,6 +46,8 @@ const fetchAgent = new Agent({
   deviceApiBaseUrl = 'https://api.ring.com/devices/v1/',
   commandsApiBaseUrl = 'https://api.ring.com/commands/v1/',
   appApiBaseUrl = 'https://prd-api-us.prd.rings.solutions/api/v1/',
+  deviceInfoApiBaseUrl = 'https://api.ring.com/device_info/v3/',
+  locationInfoApiBaseUrl = 'https://api.ring.com/location_info/v3/',
   apiVersion = 11
 
 export function clientApi(path: string) {
@@ -62,6 +64,14 @@ export function commandsApi(path: string) {
 
 export function appApi(path: string) {
   return appApiBaseUrl + path
+}
+
+export function deviceInfoApi(path: string) {
+  return deviceInfoApiBaseUrl + path
+}
+
+export function locationInfoApi(path: string) {
+  return locationInfoApiBaseUrl + path
 }
 
 export interface ExtendedResponse {

--- a/packages/ring-client-api/rest-client.ts
+++ b/packages/ring-client-api/rest-client.ts
@@ -17,6 +17,7 @@ import { ReplaySubject } from 'rxjs'
 import assert from 'assert'
 import type { Credentials } from '@eneris/push-receiver/dist/types.d.js'
 import { Agent } from 'undici'
+import { randomBytes, createHash } from 'crypto'
 
 interface RequestOptions extends RequestInit {
   responseType?: 'json' | 'buffer'
@@ -48,7 +49,55 @@ const fetchAgent = new Agent({
   appApiBaseUrl = 'https://prd-api-us.prd.rings.solutions/api/v1/',
   deviceInfoApiBaseUrl = 'https://api.ring.com/device_info/v3/',
   locationInfoApiBaseUrl = 'https://api.ring.com/location_info/v3/',
+  oauthBaseUrl = 'https://oauth.ring.com',
   apiVersion = 11
+
+function generateCodeVerifier() {
+  return randomBytes(32).toString('base64url')
+}
+
+function generateCodeChallenge(codeVerifier: string) {
+  return createHash('sha256').update(codeVerifier).digest('base64url')
+}
+
+function generateState() {
+  return randomBytes(16).toString('hex')
+}
+
+class SimpleCookieJar {
+  private cookies = new Map<string, string>()
+
+  extractFromResponse(response: Response) {
+    const setCookies = response.headers.getSetCookie()
+    for (const cookie of setCookies) {
+      const [nameValue] = cookie.split(';')
+      const eqIndex = nameValue.indexOf('=')
+      if (eqIndex !== -1) {
+        const name = nameValue.slice(0, eqIndex).trim()
+        const value = nameValue.slice(eqIndex + 1).trim()
+        this.cookies.set(name, value)
+      }
+    }
+  }
+
+  getCookieHeader() {
+    return Array.from(this.cookies.entries())
+      .map(([name, value]) => `${name}=${value}`)
+      .join('; ')
+  }
+
+  get(name: string) {
+    return this.cookies.get(name)
+  }
+}
+
+interface PendingPkceState {
+  codeVerifier: string
+  state: string
+  csrfToken: string
+  cookieJar: SimpleCookieJar
+  redirectUri: string
+}
 
 export function clientApi(path: string) {
   return clientApiBaseUrl + path
@@ -301,112 +350,445 @@ export class RingRestClient {
     }
   }
 
-  private getGrantData(twoFactorAuthCode?: string) {
-    if (this.authConfig?.rt && !twoFactorAuthCode) {
-      return {
-        grant_type: 'refresh_token',
-        refresh_token: this.authConfig.rt,
+  private pendingPkceState?: PendingPkceState
+
+  private extractCsrfToken(html: string, cookieJar: SimpleCookieJar): string {
+    // Try cookie-based CSRF token — check various common names
+    for (const name of [
+      'csrf-token',
+      'csrfToken',
+      'csrf_token',
+      '_csrf',
+      'XSRF-TOKEN',
+    ]) {
+      const cookieCsrf = cookieJar.get(name)
+      if (cookieCsrf) return cookieCsrf
+    }
+
+    // Try __NEXT_DATA__ JSON blob (Next.js page) — search deeply for csrf token
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__"[^>]*>(.*?)<\/script>/s,
+    )
+    if (nextDataMatch) {
+      try {
+        const nextData = JSON.parse(nextDataMatch[1])
+        const csrfToken = this.findCsrfInObject(nextData)
+        if (csrfToken) return csrfToken
+      } catch {
+        // fall through
       }
     }
 
-    const { authOptions } = this
-    if ('email' in authOptions) {
-      return {
-        grant_type: 'password',
-        password: authOptions.password,
-        username: authOptions.email,
+    // Try hidden input field (various name patterns)
+    const inputMatch =
+      html.match(/name="csrf-token"[^>]*value="([^"]+)"/) ||
+      html.match(/value="([^"]+)"[^>]*name="csrf-token"/) ||
+      html.match(/name="csrfToken"[^>]*value="([^"]+)"/) ||
+      html.match(/value="([^"]+)"[^>]*name="csrfToken"/) ||
+      html.match(/name="_csrf"[^>]*value="([^"]+)"/) ||
+      html.match(/value="([^"]+)"[^>]*name="_csrf"/)
+    if (inputMatch) return inputMatch[1]
+
+    // Try meta tag
+    const metaMatch =
+      html.match(
+        /meta[^>]*name="csrf-token"[^>]*content="([^"]+)"/,
+      ) || html.match(/meta[^>]*name="csrfToken"[^>]*content="([^"]+)"/)
+    if (metaMatch) return metaMatch[1]
+
+    // Try any JavaScript variable assignment that looks like a CSRF token
+    const jsMatch = html.match(
+      /["']csrf[-_]?[Tt]oken["']\s*[=:]\s*["']([^"']+)["']/,
+    )
+    if (jsMatch) return jsMatch[1]
+
+    logDebug(
+      'CSRF extraction failed. Cookies: ' + cookieJar.getCookieHeader(),
+    )
+    logDebug(
+      'HTML preview (first 2000 chars): ' + html.substring(0, 2000),
+    )
+
+    throw new Error('Unable to extract CSRF token from Ring OAuth page')
+  }
+
+  private findCsrfInObject(obj: any, depth = 0): string | undefined {
+    if (!obj || typeof obj !== 'object' || depth > 5) return undefined
+    for (const key of Object.keys(obj)) {
+      const lowerKey = key.toLowerCase()
+      if (
+        (lowerKey === 'csrftoken' || lowerKey === 'csrf' ||
+          lowerKey === 'csrf-token' || lowerKey === 'csrf_token') &&
+        typeof obj[key] === 'string'
+      ) {
+        return obj[key]
       }
+      const found = this.findCsrfInObject(obj[key], depth + 1)
+      if (found) return found
+    }
+    return undefined
+  }
+
+  private async initiatePkceFlow(): Promise<void> {
+    const codeVerifier = generateCodeVerifier()
+    const codeChallenge = generateCodeChallenge(codeVerifier)
+    const state = generateState()
+    const hardwareId = await this.hardwareIdPromise
+    const redirectUri = 'https://ring.com/signin/callback'
+    const cookieJar = new SimpleCookieJar()
+
+    const params = new URLSearchParams({
+      redirect_uri: redirectUri,
+      client_id: 'ring_official_android',
+      response_type: 'code',
+      prompt: 'login',
+      state,
+      scope: 'client',
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+      device_model: 'ring-client-api',
+      app_version: '3.102.0',
+      dark_mode: 'false',
+      device_brand: 'nodejs',
+      device_os_version: process.version,
+      app_brand: 'ring',
+      hardware_id: hardwareId,
+    })
+
+    // Initiate the OAuth flow — follow redirects manually to collect cookies
+    let currentUrl = `${oauthBaseUrl}/oauth/v2/authorize?${params}`
+    let html = ''
+
+    // Follow up to 5 redirects to reach the signin page
+    for (let i = 0; i < 5; i++) {
+      const options = {
+        method: 'GET',
+        redirect: 'manual' as const,
+        headers: {
+          'User-Agent': 'android:com.ringapp',
+          Cookie: cookieJar.getCookieHeader(),
+        },
+        dispatcher: fetchAgent,
+      }
+      const response = await fetch(currentUrl, options)
+      cookieJar.extractFromResponse(response)
+
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get('location')
+        if (!location) break
+        currentUrl = location.startsWith('/')
+          ? `${oauthBaseUrl}${location}`
+          : location
+        continue
+      }
+
+      html = await response.text()
+      break
+    }
+
+    logDebug(`Cookies after initiatePkceFlow: ${cookieJar.getCookieHeader()}`)
+    const csrfToken = this.extractCsrfToken(html, cookieJar)
+    logDebug(`Extracted CSRF token: ${csrfToken.substring(0, 20)}...`)
+
+    this.pendingPkceState = {
+      codeVerifier,
+      state,
+      csrfToken,
+      cookieJar,
+      redirectUri,
+    }
+  }
+
+  private async submitCredentials(): Promise<void> {
+    const { authOptions } = this
+    if (!('email' in authOptions) || !this.pendingPkceState) {
+      throw new Error('No pending PKCE flow or email credentials')
+    }
+
+    const { csrfToken, cookieJar } = this.pendingPkceState
+
+    const body = new URLSearchParams({
+      username: authOptions.email,
+      password: authOptions.password,
+      'csrf-token': csrfToken,
+    })
+
+    const signinPostOptions = {
+      method: 'POST',
+      redirect: 'manual' as const,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'User-Agent': 'android:com.ringapp',
+        Cookie: cookieJar.getCookieHeader(),
+      },
+      body: body.toString(),
+      dispatcher: fetchAgent,
+    }
+    const response = await fetch(
+      `${oauthBaseUrl}/oauth/v2/signin`,
+      signinPostOptions,
+    )
+
+    cookieJar.extractFromResponse(response)
+    logDebug(`Cookies after submitCredentials: ${cookieJar.getCookieHeader()}`)
+    logDebug(`submitCredentials response status: ${response.status}`)
+
+    if (response.status === 412) {
+      // 2FA required
+      const responseData = (await response.json()) as Auth2faResponse
+      this.using2fa = true
+
+      if ('tsv_state' in responseData) {
+        const { tsv_state, phone } = responseData,
+          prompt =
+            tsv_state === 'totp'
+              ? 'from your authenticator app'
+              : `sent to ${phone} via ${tsv_state}`
+
+        this.promptFor2fa = `Please enter the code ${prompt}`
+      } else {
+        this.promptFor2fa = 'Please enter the code sent to your text/email'
+      }
+
+      throw new Error(
+        'Your Ring account is configured to use 2-factor authentication (2fa).  See https://github.com/dgreif/ring/wiki/Refresh-Tokens for details.',
+      )
+    }
+
+    if (!response.ok && response.status !== 302) {
+      const errorBody = await response.text().catch(() => '')
+      throw new Error(
+        `Sign-in failed with status ${response.status}: ${errorBody}`,
+      )
+    }
+  }
+
+  private async verify2fa(code: string): Promise<void> {
+    if (!this.pendingPkceState) {
+      throw new Error('No pending PKCE flow state for 2FA verification')
+    }
+
+    const { csrfToken, cookieJar } = this.pendingPkceState
+
+    const body = new URLSearchParams({
+      '2fa_code': code,
+      'csrf-token': csrfToken,
+      remember_me: 'false',
+    })
+
+    logDebug(`2FA verify request cookies: ${cookieJar.getCookieHeader()}`)
+
+    const verifyOptions = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'User-Agent': 'android:com.ringapp',
+        Cookie: cookieJar.getCookieHeader(),
+      },
+      body: body.toString(),
+      dispatcher: fetchAgent,
+    }
+    const response = await fetch(
+      `${oauthBaseUrl}/oauth/v2/2fa/verify`,
+      verifyOptions,
+    )
+
+    cookieJar.extractFromResponse(response)
+
+    logDebug(`2FA verify response status: ${response.status}`)
+    logDebug(`2FA verify response cookies: ${cookieJar.getCookieHeader()}`)
+
+    if (response.status === 400 || response.status === 401) {
+      const responseBody = await response.text().catch(() => '')
+      logDebug(`2FA verify error body: ${responseBody}`)
+      this.promptFor2fa = 'Invalid 2fa code entered.  Please try again.'
+      throw new Error('Verification Code is invalid or expired')
+    }
+
+    if (response.status !== 200 && response.status !== 201) {
+      const responseBody = await response.text().catch(() => '')
+      logDebug(`2FA verify unexpected response: ${responseBody}`)
+      throw new Error(`2FA verification failed with status ${response.status}`)
+    }
+
+    // Read the response body to get redirect_url
+    const verifyBody = await response.json().catch(() => ({})) as any
+    logDebug(`2FA verification successful: ${JSON.stringify(verifyBody)}`)
+    logDebug(`All cookies after 2FA: ${cookieJar.getCookieHeader()}`)
+  }
+
+  private async getAuthorizationCode(): Promise<string> {
+    if (!this.pendingPkceState) {
+      throw new Error('No pending PKCE flow state')
+    }
+
+    const { state, cookieJar } = this.pendingPkceState
+
+    logDebug(
+      `Authorize code request cookies: ${cookieJar.getCookieHeader()}`,
+    )
+
+    // After 2FA, the server remembers the original authorize params from the session.
+    // We just need to revisit /oauth/v2/authorize with the session cookies.
+    let authorizeUrl = `${oauthBaseUrl}/oauth/v2/authorize`
+
+    // Follow redirects manually to find the one with the authorization code
+    for (let i = 0; i < 5; i++) {
+      const reqOptions = {
+        method: 'GET',
+        redirect: 'manual' as const,
+        headers: {
+          'User-Agent': 'android:com.ringapp',
+          Cookie: cookieJar.getCookieHeader(),
+        },
+        dispatcher: fetchAgent,
+      }
+      logDebug(`Authorize request ${i}: ${authorizeUrl}`)
+      const response = await fetch(authorizeUrl, reqOptions)
+      cookieJar.extractFromResponse(response)
+
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get('location')
+        logDebug(`Authorize redirect ${i}: ${location}`)
+
+        if (!location) {
+          throw new Error('No location header in authorize redirect')
+        }
+
+        const redirectUrl = new URL(location, oauthBaseUrl)
+        const code = redirectUrl.searchParams.get('code')
+        const returnedState = redirectUrl.searchParams.get('state')
+
+        if (code) {
+          if (returnedState !== state) {
+            throw new Error('State mismatch in OAuth response')
+          }
+          return code
+        }
+
+        // No code yet — follow this redirect
+        authorizeUrl = location.startsWith('/')
+          ? `${oauthBaseUrl}${location}`
+          : location
+        continue
+      }
+
+      // Not a redirect — log details for debugging
+      const body = await response.text().catch(() => '')
+      logDebug(
+        `Authorize non-redirect response (${response.status}): ${body.substring(0, 1000)}`,
+      )
+      throw new Error(
+        `Expected redirect from authorize but got ${response.status}`,
+      )
     }
 
     throw new Error(
-      'Refresh token is not valid.  Unable to authenticate with Ring servers.  See https://github.com/dgreif/ring/wiki/Refresh-Tokens',
+      'Failed to get authorization code after following redirects',
     )
   }
 
-  async getAuth(twoFactorAuthCode?: string): Promise<AuthTokenResponse> {
-    const grantData = this.getGrantData(twoFactorAuthCode)
+  private async exchangeCodeForTokens(
+    code: string,
+  ): Promise<AuthTokenResponse> {
+    if (!this.pendingPkceState) {
+      throw new Error('No pending PKCE flow state')
+    }
+
+    const { codeVerifier, redirectUri } = this.pendingPkceState
+    const hardwareId = await this.hardwareIdPromise
+
+    const body = new URLSearchParams({
+      code,
+      grant_type: 'authorization_code',
+      redirect_uri: redirectUri,
+      code_verifier: codeVerifier,
+      client_id: 'ring_official_android',
+    })
+
+    const tokenOptions = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+        'User-Agent': 'android:com.ringapp',
+        hardware_id: hardwareId,
+      },
+      body: body.toString(),
+      dispatcher: fetchAgent,
+    }
+    const response = await fetch(`${oauthBaseUrl}/oauth/token`, tokenOptions)
+
+    if (!response.ok) {
+      const error = await responseToError(response)
+      throw error
+    }
+
+    const tokenResponse = (await response.json()) as AuthTokenResponse
+
+    // Clean up PKCE state
+    this.pendingPkceState = undefined
+
+    return tokenResponse
+  }
+
+  private async refreshWithToken(): Promise<AuthTokenResponse> {
+    const hardwareId = await this.hardwareIdPromise
+
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: this.authConfig!.rt,
+      client_id: 'ring_official_android',
+      scope: 'client',
+    })
+
+    const response = await requestWithRetry<AuthTokenResponse>({
+      url: `${oauthBaseUrl}/oauth/token`,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+        'User-Agent': 'android:com.ringapp',
+        hardware_id: hardwareId,
+      },
+      body: body.toString(),
+    })
+
+    return response
+  }
+
+  private async authenticateWithPkce(
+    twoFactorAuthCode?: string,
+  ): Promise<AuthTokenResponse> {
+    // Track whether we've passed the 2FA stage so we can distinguish
+    // "need 2FA code" errors from post-2FA errors
+    let past2fa = false
 
     try {
-      const hardwareId = await this.hardwareIdPromise,
-        response = await requestWithRetry<AuthTokenResponse>({
-          url: 'https://oauth.ring.com/oauth/token',
-          json: {
-            client_id: 'ring_official_android',
-            scope: 'client',
-            ...grantData,
-          },
-          method: 'POST',
-          headers: {
-            '2fa-support': 'true',
-            '2fa-code': twoFactorAuthCode || '',
-            hardware_id: hardwareId,
-            'User-Agent': 'android:com.ringapp',
-          },
-        }),
-        oldRefreshToken = this.refreshToken
-
-      // Store the new refresh token and auth config
-      this.authConfig = {
-        ...this.authConfig,
-        rt: response.refresh_token,
-        hid: hardwareId,
-      }
-      this.refreshToken = toBase64(JSON.stringify(this.authConfig))
-
-      // Emit an event with the new token
-      this.onRefreshTokenUpdated.next({
-        oldRefreshToken,
-        newRefreshToken: this.refreshToken,
-      })
-
-      return {
-        ...response,
-        // Override the refresh token in the response so that consumers of this data get the wrapped version
-        refresh_token: this.refreshToken,
-      }
-    } catch (requestError: any) {
-      if (grantData.refresh_token) {
-        // failed request with refresh token
-        this.refreshToken = undefined
-        this.authConfig = undefined
-        logError(requestError)
-        return this.getAuth()
+      if (twoFactorAuthCode && this.pendingPkceState) {
+        // We have a 2FA code and an existing PKCE session — verify and continue
+        await this.verify2fa(twoFactorAuthCode)
+        past2fa = true
+      } else {
+        // Start fresh PKCE flow
+        await this.initiatePkceFlow()
+        await this.submitCredentials()
+        // If we reach here without throwing, no 2FA was needed
+        past2fa = true
       }
 
-      const response = requestError.response || {},
-        responseData: Auth2faResponse = response.body || {},
-        responseError =
-          'error' in responseData && typeof responseData.error === 'string'
-            ? responseData.error
-            : ''
+      // Get the authorization code via redirect
+      logDebug('Getting authorization code...')
+      const code = await this.getAuthorizationCode()
+      logDebug(`Got authorization code: ${code.substring(0, 10)}...`)
 
-      if (
-        response.status === 412 || // need 2fa code
-        (response.status === 400 &&
-          responseError.startsWith('Verification Code')) // invalid 2fa code entered
-      ) {
-        this.using2fa = true
-
-        if (response.status === 400) {
-          this.promptFor2fa = 'Invalid 2fa code entered.  Please try again.'
-          throw new Error(responseError)
-        }
-
-        if ('tsv_state' in responseData) {
-          const { tsv_state, phone } = responseData,
-            prompt =
-              tsv_state === 'totp'
-                ? 'from your authenticator app'
-                : `sent to ${phone} via ${tsv_state}`
-
-          this.promptFor2fa = `Please enter the code ${prompt}`
-        } else {
-          this.promptFor2fa = 'Please enter the code sent to your text/email'
-        }
-
-        throw new Error(
-          'Your Ring account is configured to use 2-factor authentication (2fa).  See https://github.com/dgreif/ring/wiki/Refresh-Tokens for details.',
-        )
+      // Exchange code for tokens
+      logDebug('Exchanging code for tokens...')
+      return await this.exchangeCodeForTokens(code)
+    } catch (error: any) {
+      // Re-throw 2FA prompt errors as-is (only when we haven't passed 2FA yet)
+      if (this.using2fa && this.promptFor2fa && !past2fa) {
+        throw error
       }
 
       const authTypeMessage =
@@ -414,17 +796,61 @@ export class RingRestClient {
             ? 'refresh token is'
             : 'email and password are',
         errorMessage =
-          'Failed to fetch oauth token from Ring. ' +
-          ('error_description' in responseData &&
-          responseData.error_description ===
-            'too many requests from dependency service'
-            ? 'You have requested too many 2fa codes.  Ring limits 2fa to 10 codes within 10 minutes.  Please try again in 10 minutes.'
-            : `Verify that your ${authTypeMessage} correct.`) +
-          ` (error: ${responseError})`
-      logError(requestError.response || requestError)
+          `Failed to fetch oauth token from Ring. Verify that your ${authTypeMessage} correct.` +
+          (error.message ? ` (error: ${error.message})` : '')
+      logError(error)
       logError(errorMessage)
       throw new Error(errorMessage)
     }
+  }
+
+  private async updateTokens(response: AuthTokenResponse) {
+    const oldRefreshToken = this.refreshToken
+    const hardwareId = await this.hardwareIdPromise
+
+    this.authConfig = {
+      ...this.authConfig,
+      rt: response.refresh_token,
+      hid: hardwareId,
+    }
+    this.refreshToken = toBase64(JSON.stringify(this.authConfig))
+
+    this.onRefreshTokenUpdated.next({
+      oldRefreshToken,
+      newRefreshToken: this.refreshToken,
+    })
+
+    return {
+      ...response,
+      refresh_token: this.refreshToken,
+    }
+  }
+
+  async getAuth(twoFactorAuthCode?: string): Promise<AuthTokenResponse> {
+    // If we have a refresh token and no 2FA code, use refresh flow
+    if (this.authConfig?.rt && !twoFactorAuthCode) {
+      try {
+        const response = await this.refreshWithToken()
+        return this.updateTokens(response)
+      } catch (e) {
+        // Refresh token failed — clear it and try email/password if available
+        this.refreshToken = undefined
+        this.authConfig = undefined
+        logError(e)
+        return this.getAuth()
+      }
+    }
+
+    // Email/password auth via PKCE
+    const { authOptions } = this
+    if ('email' in authOptions) {
+      const response = await this.authenticateWithPkce(twoFactorAuthCode)
+      return this.updateTokens(response)
+    }
+
+    throw new Error(
+      'Refresh token is not valid.  Unable to authenticate with Ring servers.  See https://github.com/dgreif/ring/wiki/Refresh-Tokens',
+    )
   }
 
   private async fetchNewSession(authToken: AuthTokenResponse) {

--- a/packages/ring-client-api/rest-client.ts
+++ b/packages/ring-client-api/rest-client.ts
@@ -64,6 +64,14 @@ function generateState() {
   return randomBytes(16).toString('hex')
 }
 
+function parseJsonBody<T>(body: string): T | undefined {
+  try {
+    return JSON.parse(body) as T
+  } catch {
+    return undefined
+  }
+}
+
 class SimpleCookieJar {
   private cookies = new Map<string, string>()
 
@@ -530,15 +538,35 @@ export class RingRestClient {
     )
 
     cookieJar.extractFromResponse(response)
+    const location = response.headers.get('location')
     logDebug(`Cookies after submitCredentials: ${cookieJar.getCookieHeader()}`)
     logDebug(`submitCredentials response status: ${response.status}`)
+    logDebug(`submitCredentials response location: ${location}`)
 
-    if (response.status === 412) {
-      // 2FA required
-      const responseData = (await response.json()) as Auth2faResponse
+    const responseBody = await response.text().catch(() => ''),
+      responseData = parseJsonBody<Auth2faResponse>(responseBody)
+    logDebug(
+      `submitCredentials response body: ${responseBody.substring(0, 1000)}`,
+    )
+
+    // Ring has historically signalled "2fa required" with a 412, but has also
+    // been seen returning 2xx (or a redirect to the 2fa page) carrying the same
+    // payload.  Detect it from the response contents rather than the status
+    // alone — missing it means we never prompt for the code Ring just sent, and
+    // the following /authorize call returns the 2fa page instead of a redirect
+    // carrying the authorization code.
+    const needs2fa =
+      response.status === 412 ||
+      Boolean(
+        responseData &&
+          ('tsv_state' in responseData || 'next_time_in_secs' in responseData),
+      ) ||
+      Boolean(location?.includes('/2fa'))
+
+    if (needs2fa) {
       this.using2fa = true
 
-      if ('tsv_state' in responseData) {
+      if (responseData && 'tsv_state' in responseData) {
         const { tsv_state, phone } = responseData,
           prompt =
             tsv_state === 'totp'
@@ -555,10 +583,9 @@ export class RingRestClient {
       )
     }
 
-    if (!response.ok && response.status !== 302) {
-      const errorBody = await response.text().catch(() => '')
+    if (!response.ok && !(response.status >= 300 && response.status < 400)) {
       throw new Error(
-        `Sign-in failed with status ${response.status}: ${errorBody}`,
+        `Sign-in failed with status ${response.status}: ${responseBody}`,
       )
     }
   }

--- a/packages/ring-client-api/ring-types.ts
+++ b/packages/ring-client-api/ring-types.ts
@@ -429,13 +429,21 @@ export interface LocationAddress {
 export interface UserLocation {
   address: LocationAddress
   created_at: string
-  geo_coordinates: { latitude: string; longitude: string }
+  geo_coordinates: { latitude: string | number; longitude: string | number }
   geo_service_verified: 'address_only' | string
   location_id: string
   name: string
   owner_id: number
   updated_at: string
   user_verified: boolean
+  is_owner?: boolean
+  operation_set?: string
+  entitlements?: {
+    business_command_center?: boolean
+    business_role_management?: boolean
+    vm_virtual_security_guard?: boolean
+  }
+  location_resource_id?: string
 }
 
 export interface TicketAsset {

--- a/packages/ring-client-api/ring-types.ts
+++ b/packages/ring-client-api/ring-types.ts
@@ -1174,6 +1174,12 @@ export type Auth2faResponse =
       tsv_state: TwoStageVerificationState
     }
 
+export interface Auth2faVerifyResponse {
+  redirect_url: string
+  status: 'auth-completed'
+  user_id: number
+}
+
 export interface ProfileResponse {
   profile: {
     id: number

--- a/packages/ring-client-api/test/rest-client.spec.ts
+++ b/packages/ring-client-api/test/rest-client.spec.ts
@@ -3,6 +3,7 @@ import { setupServer } from 'msw/node'
 import { RingRestClient } from '../rest-client.ts'
 import { clearTimeouts, getHardwareId, toBase64 } from '../util.ts'
 import { firstValueFrom } from 'rxjs'
+import { createHash } from 'crypto'
 import {
   afterAll,
   afterEach,
@@ -14,7 +15,14 @@ import {
 } from 'vitest'
 
 let sessionCreatedCount = 0,
-  client: RingRestClient
+  client: RingRestClient,
+  // Tracks whether the PKCE signin flow has been authenticated (simulates session cookies)
+  pkceAuthenticated = false,
+  // Stores the code_challenge from the initial authorize request for PKCE verification
+  storedCodeChallenge = '',
+  // Stores the state from the initial authorize request so it can be returned after auth
+  storedState = ''
+
 const email = 'some@one.com',
   password = 'abc123!',
   phone = '+1xxxxxxxx89',
@@ -25,14 +33,149 @@ const email = 'some@one.com',
   refreshToken = 'ey__refresh_token',
   secondRefreshToken = 'ey__second_refresh_token',
   thirdRefreshToken = 'ey__third_refresh_token',
+  authorizationCode = 'test_auth_code_12345',
+  csrfToken = 'test-csrf-token-abc',
   server = setupServer(
+    // GET /oauth/v2/authorize — Initiates or completes the OAuth PKCE flow
+    http.get(
+      'https://oauth.ring.com/oauth/v2/authorize',
+      ({ request: req }) => {
+        const url = new URL(req.url)
+        const codeChallenge = url.searchParams.get('code_challenge')
+        const state = url.searchParams.get('state')
+
+        if (pkceAuthenticated) {
+          // After successful signin/2FA, return 302 with authorization code
+          // Use the stored state from the initial authorize call (second call may not have params)
+          return new HttpResponse(null, {
+            status: 302,
+            headers: {
+              Location: `https://ring.com/signin/callback?code=${authorizationCode}&state=${storedState}`,
+            },
+          })
+        }
+
+        // First call — store the code_challenge and state, then redirect to signin
+        if (codeChallenge) {
+          storedCodeChallenge = codeChallenge
+        }
+        if (state) {
+          storedState = state
+        }
+
+        return new HttpResponse(null, {
+          status: 302,
+          headers: {
+            Location: '/oauth/v2/signin',
+            'Set-Cookie': 'ring_session=test-session; Path=/',
+          },
+        })
+      },
+    ),
+
+    // GET /oauth/v2/signin — Returns the signin page with CSRF token
+    http.get('https://oauth.ring.com/oauth/v2/signin', () => {
+      return new HttpResponse(
+        `<!DOCTYPE html>
+<html>
+<head><title>Ring Sign In</title></head>
+<body>
+<script id="__NEXT_DATA__" type="application/json">{"props":{"pageProps":{"csrfToken":"${csrfToken}"}}}</script>
+</body>
+</html>`,
+        {
+          headers: {
+            'Content-Type': 'text/html',
+            'Set-Cookie': 'ring_session=test-session; Path=/',
+          },
+        },
+      )
+    }),
+
+    // POST /oauth/v2/signin — Submit credentials
+    http.post(
+      'https://oauth.ring.com/oauth/v2/signin',
+      async ({ request: req }) => {
+        const body = await req.text()
+        const params = new URLSearchParams(body)
+
+        const submittedCsrf = params.get('csrf-token')
+        if (submittedCsrf !== csrfToken) {
+          return HttpResponse.json(
+            { error: 'Invalid CSRF token' },
+            { status: 403 },
+          )
+        }
+
+        const submittedEmail = params.get('username')
+        const submittedPassword = params.get('password')
+
+        if (submittedEmail !== email || submittedPassword !== password) {
+          // Wrong credentials
+          return HttpResponse.json(
+            { error: 'access_denied' },
+            { status: 401 },
+          )
+        }
+
+        // Correct credentials — return 412 requiring 2FA
+        return HttpResponse.json(
+          {
+            next_time_in_secs: 60,
+            phone,
+            tsv_state: 'sms',
+          },
+          {
+            status: 412,
+            headers: {
+              'Set-Cookie': 'ring_session=test-session-authed; Path=/',
+            },
+          },
+        )
+      },
+    ),
+
+    // POST /oauth/v2/2fa/verify — Verify 2FA code
+    http.post(
+      'https://oauth.ring.com/oauth/v2/2fa/verify',
+      async ({ request: req }) => {
+        const body = await req.text()
+        const params = new URLSearchParams(body)
+
+        const code = params.get('2fa_code')
+
+        if (code !== twoFactorAuthCode) {
+          // Wrong 2FA code
+          return HttpResponse.json(
+            { error: 'Verification Code is invalid or expired' },
+            { status: 400 },
+          )
+        }
+
+        // Correct 2FA code — mark as authenticated
+        pkceAuthenticated = true
+        return HttpResponse.json(
+          {
+            redirect_url: '/oauth/v2/authorize',
+            status: 'auth-completed',
+            user_id: 9463336,
+          },
+          {
+            status: 201,
+            headers: {
+              'Set-Cookie':
+                'ring_session=test-session-2fa-verified; Path=/',
+            },
+          },
+        )
+      },
+    ),
+
+    // POST /oauth/token — Token exchange (authorization_code or refresh_token)
     http.post(
       'https://oauth.ring.com/oauth/token',
       async ({ request: req }) => {
-        const body: any = await req.json()
-
         if (
-          req.headers.get('2fa-support') !== 'true' ||
           req.headers.get('User-Agent') !== 'android:com.ringapp' ||
           req.headers.get('hardware_id') !== (await hardwareIdPromise)
         ) {
@@ -40,39 +183,71 @@ const email = 'some@one.com',
             {
               code: 1,
               error:
-                'Invalid auth headers: ' + JSON.stringify(req.headers, null, 2),
+                'Invalid auth headers',
             },
             { status: 400 },
           )
         }
 
-        if (body.grant_type === 'refresh_token') {
-          if (body.refresh_token === refreshToken) {
-            // Valid refresh token
+        const bodyText = await req.text()
+        const params = new URLSearchParams(bodyText)
+        const grantType = params.get('grant_type')
+
+        if (grantType === 'authorization_code') {
+          const code = params.get('code')
+          const codeVerifier = params.get('code_verifier')
+          const clientId = params.get('client_id')
+
+          if (code !== authorizationCode || clientId !== 'ring_official_android') {
             return HttpResponse.json(
-              {
-                access_token: accessToken,
-                expires_in: 3600,
-                refresh_token: secondRefreshToken,
-                scope: 'client',
-                token_type: 'Bearer',
-              },
-              { status: 200 },
+              { error: 'invalid_grant' },
+              { status: 400 },
             )
           }
 
-          if (body.refresh_token === secondRefreshToken) {
-            // Valid refresh token
-            return HttpResponse.json(
-              {
-                access_token: secondAccessToken,
-                expires_in: 3600,
-                refresh_token: thirdRefreshToken,
-                scope: 'client',
-                token_type: 'Bearer',
-              },
-              { status: 200 },
-            )
+          // Verify PKCE: SHA256(code_verifier) should equal the stored code_challenge
+          if (codeVerifier && storedCodeChallenge) {
+            const computedChallenge = createHash('sha256')
+              .update(codeVerifier)
+              .digest('base64url')
+            if (computedChallenge !== storedCodeChallenge) {
+              return HttpResponse.json(
+                { error: 'invalid_grant', error_description: 'PKCE verification failed' },
+                { status: 400 },
+              )
+            }
+          }
+
+          return HttpResponse.json({
+            access_token: accessToken,
+            expires_in: 3600,
+            refresh_token: refreshToken,
+            scope: 'client',
+            token_type: 'Bearer',
+          })
+        }
+
+        if (grantType === 'refresh_token') {
+          const rt = params.get('refresh_token')
+
+          if (rt === refreshToken) {
+            return HttpResponse.json({
+              access_token: accessToken,
+              expires_in: 3600,
+              refresh_token: secondRefreshToken,
+              scope: 'client',
+              token_type: 'Bearer',
+            })
+          }
+
+          if (rt === secondRefreshToken) {
+            return HttpResponse.json({
+              access_token: secondAccessToken,
+              expires_in: 3600,
+              refresh_token: thirdRefreshToken,
+              scope: 'client',
+              token_type: 'Bearer',
+            })
           }
 
           // Invalid refresh token
@@ -85,68 +260,14 @@ const email = 'some@one.com',
           )
         }
 
-        if (
-          body.grant_type !== 'password' ||
-          body.client_id !== 'ring_official_android' ||
-          body.scope !== 'client'
-        ) {
-          return HttpResponse.json(
-            {
-              code: 1,
-              error: 'Invalid auth request: ' + JSON.stringify(body),
-            },
-            { status: 400 },
-          )
-        }
-
-        if (body.username !== email || body.password !== password) {
-          // Wrong username or password
-          return HttpResponse.json(
-            {
-              error: 'access_denied',
-              error_description: 'invalid user credentials',
-            },
-            { status: 401 },
-          )
-        }
-
-        if (
-          req.headers.get('2fa-code') &&
-          req.headers.get('2fa-code') !== twoFactorAuthCode
-        ) {
-          // Wrong 2fa code
-          return HttpResponse.json(
-            {
-              err_msg: 'bad request response from dependency service',
-              error: 'Verification Code is invalid or expired',
-            },
-            { status: 400 },
-          )
-        }
-
-        if (req.headers.get('2fa-code') === twoFactorAuthCode) {
-          // Successfull login with correct 2fa code
-          return HttpResponse.json({
-            access_token: accessToken,
-            expires_in: 3600,
-            refresh_token: refreshToken,
-            scope: 'client',
-            token_type: 'Bearer',
-            responseTimestamp: Date.now(),
-          })
-        }
-
-        // 2fa code not provided, so return the 2fa prompt
         return HttpResponse.json(
-          {
-            next_time_in_secs: 60,
-            phone,
-            tsv_state: 'sms',
-          },
-          { status: 412 },
+          { error: 'unsupported_grant_type' },
+          { status: 400 },
         )
       },
     ),
+
+    // POST /clients_api/session — Session creation
     http.post(
       'https://api.ring.com/clients_api/session',
       async ({ request: req }) => {
@@ -195,6 +316,9 @@ async function wrapRefreshToken(rt: string) {
 
 beforeEach(() => {
   sessionCreatedCount = 0
+  pkceAuthenticated = false
+  storedCodeChallenge = ''
+  storedState = ''
 })
 
 beforeAll(() => {
@@ -255,7 +379,7 @@ describe('getAuth', () => {
     })
 
     await expect(() => client.getAuth()).rejects.toThrow(
-      'Failed to fetch oauth token from Ring. Verify that your email and password are correct. (error: access_denied)',
+      'Failed to fetch oauth token from Ring. Verify that your email and password are correct.',
     )
   })
 
@@ -265,7 +389,7 @@ describe('getAuth', () => {
       email,
     })
 
-    // ignore the first reject, it's it('ove
+    // ignore the first reject, it triggers 2fa prompt
     await expect(() => client.getAuth()).rejects.toThrow()
 
     // call getAuth again with an invalid 2fa code, which should fail
@@ -305,6 +429,23 @@ describe('getAuth', () => {
       oldRefreshToken: refreshToken,
       newRefreshToken: await wrapRefreshToken(secondRefreshToken),
     })
+  })
+
+  it('should verify PKCE code_verifier matches code_challenge', async () => {
+    client = new RingRestClient({
+      password,
+      email,
+    })
+
+    // First call triggers 2FA
+    await expect(() => client.getAuth()).rejects.toThrow()
+
+    // Second call with valid 2FA code should succeed with valid PKCE verification
+    const auth = await client.getAuth(twoFactorAuthCode)
+    expect(auth.access_token).toEqual(accessToken)
+
+    // Verify that a code_challenge was stored by the mock (meaning PKCE params were sent)
+    expect(storedCodeChallenge).toBeTruthy()
   })
 })
 


### PR DESCRIPTION
This is the second in a series of PRs to bring ring-client-api on par with modern Ring API specs.  Please note that, while I've done my best to keep the PRs independent, it's very difficult to develop these changes without some depedency on prior PRs.

While I have tested these changes with ring-mqtt, the modifications are in core functions that have remained largely unchaged for many years so this PR has more risk than many.

The official Ring app has implemented the standard OAuth 2.0 with PKCE flow as the default authentication method for some time, but it still has a fall back to the legacy direct password grant API method which is still used by ring-client-api today.  However, more recently it appears Ring has tightened the security around the legacy API endpoint and some users have expeirenced various issues performing authentication with the API.

This PR implements this new authentication workflow.  I have tested this flow extensively and it works, however, this flow is more fragile than the previous API flow and could be impacted by changes to the Ring auth web page, although such changes would likely also implement their own app so I'm hopeful it will not be common.  This should make auth requests less picky to things like the user agent string, since the oauth flow is generally performed via a browser instead of natively in the app.

Important Note: This code was written 99% by Claude Code.  I did have to do a some manual debugging as the OAuth process is very picky with regards to token handling and headers.  The overall flow is signfiicantly more complex than the previous method, but I'm not sure if it's avoidable as it's the same patter for many modern apps and I've had to do the same for other projects as well.