### PR TITLE
feat: support Kidde smoke-only alarm

### DIFF
--- a/.changeset/kidde-smoke-alarm-support.md
+++ b/.changeset/kidde-smoke-alarm-support.md
@@ -1,0 +1,6 @@
+---
+'ring-client-api': minor
+'homebridge-ring': minor
+---
+
+Add support for Kidde Ring Smoke Alarm device (comp.bluejay.sensor_bluejay_s)

--- a/packages/homebridge-ring/ring-platform.ts
+++ b/packages/homebridge-ring/ring-platform.ts
@@ -94,6 +94,7 @@ function getAccessoryClass(
     case RingDeviceType.Keypad:
       return BrightnessOnly
     case RingDeviceType.SmokeAlarm:
+    case RingDeviceType.KiddeSmokeAlarm:
       return SmokeAlarm
     case RingDeviceType.CoAlarm:
       return CoAlarm

--- a/packages/homebridge-ring/smoke-alarm.ts
+++ b/packages/homebridge-ring/smoke-alarm.ts
@@ -29,7 +29,10 @@ export class SmokeAlarm extends BaseDeviceAccessory {
       characteristicType: SmokeDetected,
       serviceType: SmokeSensor,
       getValue: (data) => {
-        return data.alarmStatus === 'active'
+        const smokeAlarmStatus =
+          data.alarmStatus ??
+          data.components?.['alarm.smoke']?.alarmStatus
+        return smokeAlarmStatus === 'active'
           ? SmokeDetected.SMOKE_DETECTED
           : SmokeDetected.SMOKE_NOT_DETECTED
       },

--- a/packages/ring-client-api/ring-types.ts
+++ b/packages/ring-client-api/ring-types.ts
@@ -47,6 +47,7 @@ export const RingDeviceType = {
   IntercomHandsetVideo: 'intercom_handset_video',
   WaterValve: 'valve.water',
   KiddeSmokeCoAlarm: 'comp.bluejay.sensor_bluejay_wsc',
+  KiddeSmokeAlarm: 'comp.bluejay.sensor_bluejay_s',
 } as const
 // eslint-disable-next-line no-redeclare
 export type RingDeviceType =
@@ -239,7 +240,7 @@ export interface RingDeviceData {
   alarmStatus?: 'active'
   co?: { alarmStatus?: 'active' | 'inactive' }
   smoke?: { alarmStatus?: 'active' | 'inactive' }
-  // Kidde Smoke/CO Alarm (comp.bluejay.sensor_bluejay_wsc)
+  // Kidde Smoke/CO Alarm (comp.bluejay.sensor_bluejay_wsc, comp.bluejay.sensor_bluejay_s)
   components?: {
     'alarm.co'?: { alarmStatus?: 'active' | 'inactive' }
     'alarm.smoke'?: { alarmStatus?: 'active' | 'inactive' }


### PR DESCRIPTION
## Summary

Adds support for the Kidde smoke-only alarm (`comp.bluejay.sensor_bluejay_s`) across `ring-client-api` and `homebridge-ring`.

This is the smoke-only counterpart to the existing Kidde Smoke/CO alarm support and enables the device to be recognized and exposed as a HomeKit smoke sensor.

## Changes

- Adds `RingDeviceType.KiddeSmokeAlarm` for `comp.bluejay.sensor_bluejay_s`.
- Maps the device type to the existing `SmokeAlarm` Homebridge accessory.
- Reads smoke state from `components['alarm.smoke'].alarmStatus`, while preserving support for devices that provide `alarmStatus` at the top level.
- Includes changesets for minor releases of `ring-client-api` and `homebridge-ring`.

## Testing

- [x] Verified the smoke-only device is recognized as `KiddeSmokeAlarm`.
- [x] Verified Homebridge exposes it as a smoke sensor.
- [x] Verified the smoke state updates from `inactive` to `active`.

I do not have a safe way to trigger a live smoke alarm for end-to-end testing. The component structure and smoke-state handling follow the existing Kidde Smoke/CO device pattern.