### PR TITLE
chore(ring-client-api): remove deprecated @types/uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2202,17 +2202,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "*"
-      }
-    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "dev": true,
@@ -6825,7 +6814,6 @@
         "@types/debug": "4.1.13",
         "@types/json-bigint": "^1.0.4",
         "@types/node": "25.9.1",
-        "@types/uuid": "11.0.0",
         "@types/ws": "^8.18.1",
         "eslint-config-shared": "*",
         "msw": "^2.14.6",

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
   "workspaces": [
     "packages/*"
   ],
-  "packageManager": "npm@11.8.0"
+  "packageManager": "npm@11.17.0"
 }

--- a/packages/ring-client-api/package.json
+++ b/packages/ring-client-api/package.json
@@ -54,7 +54,6 @@
     "@types/debug": "4.1.13",
     "@types/json-bigint": "^1.0.4",
     "@types/node": "25.9.1",
-    "@types/uuid": "11.0.0",
     "@types/ws": "^8.18.1",
     "eslint-config-shared": "*",
     "msw": "^2.14.6",


### PR DESCRIPTION
## Summary

- Removes `@types/uuid` from `ring-client-api` devDependencies.
- `uuid` v14 (already a dependency) includes its own TypeScript definitions; npm marks `@types/uuid` as a deprecated stub that only re-exports `uuid`.
- Updates `package-lock.json` via `npm install`.

## Test plan

- [x] `npm run build -w ring-client-api`