### PR TITLE
Remove deprecated StreamingSession.activate()

### DIFF
--- a/.changeset/remove-streaming-session-activate.md
+++ b/.changeset/remove-streaming-session-activate.md
@@ -1,0 +1,5 @@
+---
+"ring-client-api": major
+---
+
+Remove deprecated `StreamingSession.activate()`. It was a thin wrapper around `requestKeyFrame()` and had been marked deprecated for some time. Call `requestKeyFrame()` directly instead to explicitly request an initial key frame.

--- a/packages/ring-client-api/streaming/streaming-session.ts
+++ b/packages/ring-client-api/streaming/streaming-session.ts
@@ -61,14 +61,6 @@ export class StreamingSession extends Subscribed {
     )
   }
 
-  /**
-   * @deprecated
-   * activate will be removed in the future. Please use requestKeyFrame if you want to explicitly request an initial key frame
-   */
-  activate() {
-    this.requestKeyFrame()
-  }
-
   cameraSpeakerActivated = false
   activateCameraSpeaker() {
     if (this.cameraSpeakerActivated || this.hasEnded) {


### PR DESCRIPTION
## Summary
- Removes the deprecated `StreamingSession.activate()` method, which was a thin wrapper around `requestKeyFrame()` with no remaining callers
- Confirmed `WebrtcConnection.activate()` is a separate private method (sends `activate_session` to keep streams alive) and was intentionally left unchanged
- `StreamingSessionWrapper.activate()` in homebridge-ring is unrelated and unchanged

## Test plan
- [x] `npm run build -w ring-client-api`
- [x] `npm test -w ring-client-api` (18 tests passed)


Made with [Cursor](https://cursor.com)