### PR TITLE
Fix exit-beta npm script typo (git commit)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "deploy": "changeset version && git commit -am 'Bump versions for release' && changeset publish",
     "release": "turbo run build test lint && changeset publish",
     "prepare-beta": "changeset pre enter beta && changeset version && git add .changeset/pre.json && git commit -am 'Prepare for beta release' && git push --follow-tags",
-    "exit-beta": "changeset pre exit && changeset version && commit -am 'Exit beta release and create main release' && git push --follow-tags"
+    "exit-beta": "changeset pre exit && changeset version && git commit -am 'Exit beta release and create main release' && git push --follow-tags"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",


### PR DESCRIPTION
## Summary
- Fixes the root `exit-beta` npm script to use `git commit -am` instead of bare `commit -am`, matching `deploy` and `prepare-beta`.

## Test plan
- [ ] Verify `npm run exit-beta` would invoke `git commit` (dry-run or read script in package.json)


Made with [Cursor](https://cursor.com)