### PR TITLE
fix: silence Turbo warning for examples#build

### DIFF
--- a/packages/examples/turbo.json
+++ b/packages/examples/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `packages/examples/turbo.json` with `build.outputs: []` so Turbo does not expect `lib/**` from the examples typecheck-only build (`tsc --noEmit`).
- Turbo 2.x does not apply root-level `examples#build` task keys; package configuration with `"extends": ["//"]` is the supported override.

## Test plan
- [x] `npm run build` completes without `WARNING no output files found for task examples#build`


Made with [Cursor](https://cursor.com)