### PR TITLE
chore: align packageManager to npm 11.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
   "workspaces": [
     "packages/*"
   ],
-  "packageManager": "npm@11.8.0"
+  "packageManager": "npm@11.17.0"
 }


### PR DESCRIPTION
## Summary
- Updates root `packageManager` from `npm@11.8.0` to `npm@11.17.0` (latest stable npm 11.x).
- Keeps Corepack pinned to a current npm 11 release so dev and CI use the same npm version.

## Test plan
- [ ] `corepack enable` / `corepack prepare` picks up `npm@11.17.0` from `package.json`
- [ ] CI install step continues to succeed with the pinned version

Made with [Cursor](https://cursor.com)