### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a TypeScript monorepo (npm workspaces + turbo). Packages live in `packages/`:
+
+- `ring-client-api` — the unofficial Ring API client library.
+- `homebridge-ring` — the Homebridge plugin (the runnable "app").
+- `examples` — runnable example scripts / CLIs using `ring-client-api`.
+- `eslint-config-shared`, `tsconfig` — shared internal configs.
+
+### Standard commands (run from repo root, driven by turbo)
+
+- Build: `npm run build`
+- Lint: `npm run lint`
+- Test: `npm test` (vitest + `msw`; mocks Ring servers, so no network/credentials needed)
+- Run the Homebridge app in watch mode: `npm run dev`
+
+See `.github/DEVELOPMENT.md` for the full dev workflow and `README.md` for package overviews.
+
+### Node version gotcha (important)
+
+`npm run dev`, the example scripts, and the `ring-*-cli` scripts run the TypeScript
+source directly via Node's **native type stripping**, which is only enabled by default
+on Node `>= 22.18` (or `>= 24`). The base `node` on `PATH` (`/exec-daemon/node`) is an
+older 22.x and will fail with `Unknown file extension ".ts"`.
+
+This environment installs a newer Node via `nvm` (default: node 24) and `~/.bashrc`
+prepends it to `PATH`, so **login/interactive shells (including tmux sessions) already
+use the correct node**. `npm run build|lint|test` work on any supported node.
+
+If `node --version` ever reports an older 22.x (e.g. `v22.14.0`) and dev/example/CLI
+commands fail with the `.ts` extension error, run them in a login shell (`bash -lic '...'`)
+or `nvm use default` to activate the newer node.
+
+### Running the app / examples against real Ring devices
+
+Connecting to real Ring devices requires a `RING_REFRESH_TOKEN` in a repo-root `.env`
+file (gitignored), generated via `npm run auth-cli` (needs real Ring credentials + 2FA).
+Without it, `npm run dev` still boots Homebridge and initializes the Ring platform but
+logs "Plugin is not configured"; the example/CLI scripts exit early.
+
+Homebridge dev also reads a gitignored `.homebridge/config.json` at the repo root
+(create one with a `{"platform": "Ring"}` entry under `platforms`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this monorepo, and adds an `AGENTS.md` documenting durable, non-obvious setup notes for future Cloud Agents.

The only committed change is the new `AGENTS.md`. No application code was modified.

## What was verified

- `npm ci` — installs all workspace deps.
- `npm run build` — all 3 packages build (turbo).
- `npm run lint` — clean across all packages.
- `npm test` — 18/18 vitest tests pass (`ring-client-api`, mocked Ring servers via `msw`).
- `npm run dev` — Homebridge boots, loads `homebridge-ring@14.3.0` from TypeScript source, registers/initializes the `Ring` platform, and publishes a pairable HomeKit bridge.

## Key gotcha captured in AGENTS.md

`npm run dev` / example scripts / CLIs rely on Node's native TypeScript type-stripping, which requires Node `>= 22.18` (or `>= 24`). The base `node` on `PATH` is an older 22.x that fails with `Unknown file extension ".ts"`. The environment now uses an `nvm`-managed newer node (default 24) via a `~/.bashrc` prepend so login/tmux shells work out of the box; build/lint/test work on any supported node.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f06d324c-43e4-4773-ba60-9ea6babe46df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f06d324c-43e4-4773-ba60-9ea6babe46df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

