### PR TITLE
fix(ring-client-api): summarize ignored startup push notifications

### DIFF
--- a/.changeset/summarize-startup-push-ignores.md
+++ b/.changeset/summarize-startup-push-ignores.md
@@ -1,0 +1,5 @@
+---
+"ring-client-api": patch
+---
+
+Summarize ignored startup push notifications into a single log line instead of one line per notification.

--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -27,6 +27,7 @@ import {
 } from 'rxjs/operators'
 import {
   clearTimeouts,
+  delay,
   enableDebug,
   logDebug,
   logError,
@@ -315,14 +316,28 @@ export class RingApi extends Subscribed {
       logError(e)
     }
 
-    const startTime = Date.now()
+    // Ignore messages received in the first two seconds after connecting.
+    // These are likely duplicates, and we aren't currently storing persistent
+    // ids anywhere to avoid re-processing them. Summarize once so busy accounts
+    // don't flood Homebridge logs with one line per ignored notification.
+    const pushIgnoreWindowMs = 2000,
+      startTime = Date.now()
+    let ignoredPushCount = 0
+    delay(pushIgnoreWindowMs)
+      .then(() => {
+        if (ignoredPushCount > 0) {
+          logInfo(
+            `Ignored ${ignoredPushCount} push notification(s) received in the first ${
+              pushIgnoreWindowMs / 1000
+            } seconds after starting up`,
+          )
+        }
+      })
+      .catch(logError)
+
     pushReceiver.onNotification(({ message }) => {
-      // Ignore messages received in the first two seconds after connecting
-      // These are likely duplicates, and we aren't currently storying persistent ids anywhere to avoid re-processing them
-      if (Date.now() - startTime < 2000) {
-        logInfo(
-          'Ignoring push notification received in first two seconds after starting up',
-        )
+      if (Date.now() - startTime < pushIgnoreWindowMs) {
+        ignoredPushCount++
         return
       }
 


### PR DESCRIPTION
## Summary
- During the intentional 2s startup push-ignore window, Ring often delivers dozens of queued notifications.
- Each ignored notification was logged at info level, flooding Homebridge logs on every restart.
- Count ignores and emit a single summary line after the window (e.g. `Ignored 63 push notification(s)...`).

Fixes #1800

Related: #1681 (closed as not planned when framed as a bug; this keeps the ignore behavior and only reduces log noise).

## Test plan
- [x] `npm run lint -w ring-client-api`
- [x] `npm run test -w ring-client-api`
- [ ] Restart homebridge-ring and confirm one summary line instead of many identical ignore messages