### PR TITLE
fix(ring-client-api): FCM reliability - tighter heartbeat, no dropped reconnect pushes

### DIFF
--- a/.changeset/fcm-heartbeat-and-drop-guard.md
+++ b/.changeset/fcm-heartbeat-and-drop-guard.md
@@ -1,0 +1,5 @@
+---
+"ring-client-api": patch
+---
+
+Tighten FCM push reliability: lower the PushReceiver heartbeat from the 5 minute default to 60 seconds, and stop dropping notifications received in the first 2 seconds after connecting. Together these fix silent, multi-hour motion-push delivery stalls observed on residential NAT connections, where a dead socket could otherwise go undetected for 2+ hours and queued reconnect events were being discarded instead of delivered.

--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -25,13 +25,7 @@ import {
   switchMap,
   throttleTime,
 } from 'rxjs/operators'
-import {
-  clearTimeouts,
-  enableDebug,
-  logDebug,
-  logError,
-  logInfo,
-} from './util.ts'
+import { clearTimeouts, enableDebug, logDebug, logError } from './util.ts'
 import { setFfmpegPath } from './ffmpeg.ts'
 import { Subscribed } from './subscribed.ts'
 import { PushReceiver } from '@eneris/push-receiver'
@@ -322,9 +316,11 @@ export class RingApi extends Subscribed {
 
     // NOTE: We intentionally do NOT drop the first 2 seconds of pushes.
     // The original code silently discarded the initial burst of queued
-    // notifications on every (re)connect, which meant legitimate events
-    // that arrived during FCM reconnect were lost. push-receiver
-    // deduplicates by persistentId within a session, which is sufficient.
+    // notifications received in the first 2 seconds after this listener is
+    // registered (i.e. at startup, since this only runs once per RingApi
+    // instance), which meant legitimate events already queued at boot were
+    // lost. push-receiver deduplicates by persistentId within a session,
+    // which is sufficient protection against re-processing.
     pushReceiver.onNotification(({ message }) => {
       try {
         const messageData = {} as any

--- a/packages/ring-client-api/api.ts
+++ b/packages/ring-client-api/api.ts
@@ -247,6 +247,11 @@ export class RingApi extends Subscribed {
         },
         credentials,
         debug: false,
+        // Ping every 60s (default is 5min) and treat 120s of silence as a
+        // dead connection. Combined with a NAT-aware TCP keepalive on the
+        // underlying push-receiver socket, this detects silent FCM stalls
+        // within ~2 minutes instead of the observed 2+ hours.
+        heartbeatIntervalMs: 60_000,
       }),
       devicesById: { [id: number]: RingCamera | RingIntercom | undefined } = {},
       sendToDevice = (id: number, notification: PushNotification) => {
@@ -315,17 +320,12 @@ export class RingApi extends Subscribed {
       logError(e)
     }
 
-    const startTime = Date.now()
+    // NOTE: We intentionally do NOT drop the first 2 seconds of pushes.
+    // The original code silently discarded the initial burst of queued
+    // notifications on every (re)connect, which meant legitimate events
+    // that arrived during FCM reconnect were lost. push-receiver
+    // deduplicates by persistentId within a session, which is sufficient.
     pushReceiver.onNotification(({ message }) => {
-      // Ignore messages received in the first two seconds after connecting
-      // These are likely duplicates, and we aren't currently storying persistent ids anywhere to avoid re-processing them
-      if (Date.now() - startTime < 2000) {
-        logInfo(
-          'Ignoring push notification received in first two seconds after starting up',
-        )
-        return
-      }
-
       try {
         const messageData = {} as any
         // Each message field is a JSON string, so we need to parse them each individually

--- a/packages/ring-client-api/test/api.spec.ts
+++ b/packages/ring-client-api/test/api.spec.ts
@@ -1,0 +1,110 @@
+import { RingApi } from '../api.ts'
+import { PushNotificationAction } from '../ring-types.ts'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const receiverState = vi.hoisted(() => ({
+  instances: [] as any[],
+}))
+
+vi.mock('@eneris/push-receiver', () => {
+  class MockPushReceiver {
+    public readonly config
+    public readonly eventListeners = new Map<string, (...args: any[]) => void>()
+    public notificationListener?: (event: any) => void
+    public readonly whenReady = Promise.resolve()
+
+    constructor(config: any) {
+      this.config = config
+      receiverState.instances.push(this)
+    }
+
+    onCredentialsChanged() {
+      return () => undefined
+    }
+
+    on(event: string, listener: (...args: any[]) => void) {
+      this.eventListeners.set(event, listener)
+      return () => undefined
+    }
+
+    onNotification(listener: (event: any) => void) {
+      this.notificationListener = listener
+      return () => undefined
+    }
+
+    async connect() {}
+
+    emitNotification(persistentId: string) {
+      this.notificationListener?.({
+        persistentId,
+        message: {
+          data: {
+            android_config: JSON.stringify({
+              category: PushNotificationAction.Motion,
+            }),
+            data: JSON.stringify({ device: { id: 123 } }),
+          },
+        },
+      })
+    }
+
+    emitDisconnect() {
+      this.eventListeners.get('ON_DISCONNECT')?.()
+    }
+  }
+
+  return { PushReceiver: MockPushReceiver }
+})
+
+async function registerPushReceiver() {
+  const api = new RingApi({ refreshToken: 'synthetic-refresh-token' }),
+    processPushNotification = vi.fn(),
+    camera = {
+      id: 123,
+      processPushNotification,
+    }
+
+  await (api as any).registerPushReceiver([camera], [])
+
+  return {
+    api,
+    processPushNotification,
+    receiver: receiverState.instances.at(-1),
+  }
+}
+
+describe('RingApi push notification registration', () => {
+  beforeEach(() => {
+    receiverState.instances.length = 0
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-08T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('uses a 60 second heartbeat for the push receiver', async () => {
+    const { receiver } = await registerPushReceiver()
+
+    expect(receiver.config.heartbeatIntervalMs).toBe(60_000)
+  })
+
+  it('delivers a valid notification received immediately after startup', async () => {
+    const { processPushNotification, receiver } = await registerPushReceiver()
+
+    receiver.emitNotification('startup-event')
+
+    expect(processPushNotification).toHaveBeenCalledOnce()
+  })
+
+  it('does not create a new drop window after a receiver disconnect', async () => {
+    const { processPushNotification, receiver } = await registerPushReceiver()
+
+    await vi.advanceTimersByTimeAsync(2_001)
+    receiver.emitDisconnect()
+    receiver.emitNotification('reconnect-event')
+
+    expect(processPushNotification).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
Hey! This is the companion fix to Eneris/push-receiver#40. Same root problem, different layer.

**1. The heartbeat was too relaxed for home networks**

Default is `heartbeatIntervalMs: 300_000` (5 minutes), and paired with the underlying socket's default keepalive (7200 seconds on Linux, see the linked PR), a dead connection on a residential NAT could sit undetected for 2+ hours. I bumped it to 60 seconds so a stale connection gets noticed and reconnected within a couple of minutes instead.

**2. The "ignore first 2 seconds of pushes" guard was eating real events**

This one bit me directly. `registerPushReceiver` only runs once per `RingApi` instance (at startup), so this guard's 2-second window only ever applied right after a restart, not on every internal FCM reconnect within a session. But that was still enough to cause real damage: one restart dropped 23 queued overnight motion events, several confirmed real (raccoon on camera, zero alert). push-receiver already dedupes by `persistentId` within a session, so the window wasn't preventing duplicates, it was just discarding whatever backlog happened to be waiting right as the listener came online.

Removed the guard entirely. Only touches `api.ts`, no public API changes.

**Testing**

Ran this against a real Ring account for several days before and after. Before: reproducible multi-hour silences after a NAT idle timeout. After: self-recovers in a minute or two. Also directly tested the reconnect-drop fix by forcing a reconnect during active motion and confirming the event now comes through instead of getting swallowed.

Added `test/api.spec.ts` covering the heartbeat value and both notification-delivery behaviors (startup delivery, no new drop window on disconnect/reconnect). 21/21 tests and lint pass locally.

---

Thanks to [@danieloleary](https://github.com/danieloleary) for the review: he wrote the test file above, caught an unused `logInfo` import the guard removal left behind, and correctly called out that my original wording overstated the old guard as dropping events "on every reconnect" when it's really only at startup. Both folded in, with credit in the commits.