### PR TITLE
Preserve HomeKit streams after Ring answered timeout

### DIFF
--- a/.changeset/continue-answered-timeout-streams.md
+++ b/.changeset/continue-answered-timeout-streams.md
@@ -1,0 +1,5 @@
+---
+"ring-client-api": patch
+---
+
+Keep RTP sequence numbers and timestamps continuous when a Ring live view reconnects after an `answered_timeout`.

--- a/packages/ring-client-api/ring-camera.ts
+++ b/packages/ring-client-api/ring-camera.ts
@@ -438,10 +438,8 @@ export class RingCamera extends Subscribed {
     }
 
     const connection = await this.createStreamingConnection(options)
-    return new StreamingSession(
-      this,
-      connection,
-      () => this.createStreamingConnection(options),
+    return new StreamingSession(this, connection, () =>
+      this.createStreamingConnection(options),
     )
   }
 

--- a/packages/ring-client-api/ring-camera.ts
+++ b/packages/ring-client-api/ring-camera.ts
@@ -438,7 +438,11 @@ export class RingCamera extends Subscribed {
     }
 
     const connection = await this.createStreamingConnection(options)
-    return new StreamingSession(this, connection)
+    return new StreamingSession(
+      this,
+      connection,
+      () => this.createStreamingConnection(options),
+    )
   }
 
   private removeDingById(idToRemove: string) {

--- a/packages/ring-client-api/streaming/streaming-session.ts
+++ b/packages/ring-client-api/streaming/streaming-session.ts
@@ -41,12 +41,18 @@ export class StreamingSession extends Subscribed {
   private readonly returnAudioSplitter = new RtpSplitter()
   private readonly camera
   private connection
+  private readonly createConnection
 
-  constructor(camera: RingCamera, connection: WebrtcConnection) {
+  constructor(
+    camera: RingCamera,
+    connection: WebrtcConnection,
+    createConnection: () => Promise<WebrtcConnection>,
+  ) {
     super()
 
     this.camera = camera
     this.connection = connection
+    this.createConnection = createConnection
     this.bindToConnection(connection)
   }
 
@@ -57,7 +63,14 @@ export class StreamingSession extends Subscribed {
       connection.onCallAnswered.subscribe((sdp) => {
         this.onUsingOpus.next(sdp.toLocaleLowerCase().includes(' opus/'))
       }),
-      connection.onCallEnded.subscribe(() => this.callEnded()),
+      connection.onCallEnded.subscribe((reason) => {
+        if (reason?.code === 10 && reason.text === 'answered_timeout') {
+          void this.reconnect()
+          return
+        }
+
+        this.callEnded()
+      }),
     )
   }
 
@@ -221,6 +234,34 @@ export class StreamingSession extends Subscribed {
         },
       })
     this.onCallEnded.pipe(take(1)).subscribe(() => ff.stop())
+  }
+
+  private reconnecting = false
+
+  private async reconnect() {
+    if (this.reconnecting || this.hasEnded) {
+      return
+    }
+
+    this.reconnecting = true
+
+    try {
+      const connection = await this.createConnection()
+
+      if (this.hasEnded) {
+        connection.stop()
+        return
+      }
+
+      this.connection = connection
+      this.bindToConnection(connection)
+    } catch (error) {
+      logError(`Failed to reconnect stream for ${this.camera.name}`)
+      logError(error)
+      this.callEnded()
+    } finally {
+      this.reconnecting = false
+    }
   }
 
   private hasEnded = false

--- a/packages/ring-client-api/streaming/streaming-session.ts
+++ b/packages/ring-client-api/streaming/streaming-session.ts
@@ -7,12 +7,26 @@ import {
 import { firstValueFrom, ReplaySubject, Subject } from 'rxjs'
 import type { WebrtcConnection } from './webrtc-connection.ts'
 import { getFfmpegPath } from '../ffmpeg.ts'
-import { logDebug, logError } from '../util.ts'
+import { logDebug, logError, logInfo } from '../util.ts'
 import type { RingCamera } from '../ring-camera.ts'
 import { concatMap, map, mergeWith, take } from 'rxjs/operators'
 import { Subscribed } from '../subscribed.ts'
 
 type SpawnInput = string | number
+type RtpState = {
+  generation: number
+  inputSequenceNumber: number
+  inputTimestamp: number
+  outputSequenceNumber: number
+  outputTimestamp: number
+  timestampIncrement: number
+}
+
+function unsignedDelta(value: number, previousValue: number, bits: 16 | 32) {
+  const modulus = 2 ** bits
+  return (value - previousValue + modulus) % modulus
+}
+
 export interface FfmpegOptions {
   input?: SpawnInput[]
   video?: SpawnInput[] | false
@@ -42,6 +56,9 @@ export class StreamingSession extends Subscribed {
   private readonly camera
   private connection
   private readonly createConnection
+  private videoRtpState?: RtpState
+  private audioRtpState?: RtpState
+  private connectionGeneration = 0
 
   constructor(
     camera: RingCamera,
@@ -57,21 +74,87 @@ export class StreamingSession extends Subscribed {
   }
 
   private bindToConnection(connection: WebrtcConnection) {
+    const generation = this.connectionGeneration++
+
     this.addSubscriptions(
-      connection.onAudioRtp.subscribe(this.onAudioRtp),
-      connection.onVideoRtp.subscribe(this.onVideoRtp),
+      connection.onAudioRtp.subscribe((rtp) => {
+        this.forwardRtp(rtp, 'audio', generation)
+      }),
+      connection.onVideoRtp.subscribe((rtp) => {
+        this.forwardRtp(rtp, 'video', generation)
+      }),
       connection.onCallAnswered.subscribe((sdp) => {
         this.onUsingOpus.next(sdp.toLocaleLowerCase().includes(' opus/'))
+
+        if (generation > 0) {
+          logInfo(`Reconnected stream for ${this.camera.name}`)
+          connection.requestKeyFrame()
+        }
       }),
       connection.onCallEnded.subscribe((reason) => {
         if (reason?.code === 10 && reason.text === 'answered_timeout') {
-          void this.reconnect()
+          this.reconnect().catch(logError)
           return
         }
 
         this.callEnded()
       }),
     )
+  }
+
+  private forwardRtp(
+    rtp: RtpPacket,
+    media: 'audio' | 'video',
+    generation: number,
+  ) {
+    const stateProperty = media === 'video' ? 'videoRtpState' : 'audioRtpState',
+      subject = media === 'video' ? this.onVideoRtp : this.onAudioRtp,
+      state = this[stateProperty]
+
+    if (!state) {
+      this[stateProperty] = {
+        generation,
+        inputSequenceNumber: rtp.header.sequenceNumber,
+        inputTimestamp: rtp.header.timestamp,
+        outputSequenceNumber: rtp.header.sequenceNumber,
+        outputTimestamp: rtp.header.timestamp,
+        timestampIncrement: media === 'video' ? 3000 : 960,
+      }
+      subject.next(rtp)
+      return
+    }
+
+    const isNewConnection = state.generation !== generation,
+      sequenceIncrement = isNewConnection
+        ? 1
+        : unsignedDelta(
+            rtp.header.sequenceNumber,
+            state.inputSequenceNumber,
+            16,
+          ),
+      inputTimestampIncrement = unsignedDelta(
+        rtp.header.timestamp,
+        state.inputTimestamp,
+        32,
+      ),
+      timestampIncrement = isNewConnection
+        ? state.timestampIncrement
+        : inputTimestampIncrement
+
+    state.generation = generation
+    state.inputSequenceNumber = rtp.header.sequenceNumber
+    state.inputTimestamp = rtp.header.timestamp
+    state.outputSequenceNumber =
+      (state.outputSequenceNumber + sequenceIncrement) & 0xffff
+    state.outputTimestamp = (state.outputTimestamp + timestampIncrement) >>> 0
+
+    if (!isNewConnection && inputTimestampIncrement > 0) {
+      state.timestampIncrement = inputTimestampIncrement
+    }
+
+    rtp.header.sequenceNumber = state.outputSequenceNumber
+    rtp.header.timestamp = state.outputTimestamp
+    subject.next(rtp)
   }
 
   /**
@@ -254,6 +337,7 @@ export class StreamingSession extends Subscribed {
       }
 
       this.connection = connection
+      logInfo(`Reconnecting stream for ${this.camera.name}`)
       this.bindToConnection(connection)
     } catch (error) {
       logError(`Failed to reconnect stream for ${this.camera.name}`)

--- a/packages/ring-client-api/streaming/webrtc-connection.ts
+++ b/packages/ring-client-api/streaming/webrtc-connection.ts
@@ -27,7 +27,9 @@ export class WebrtcConnection extends Subscribed {
   private readonly dialogId = generateUuid()
   readonly onCameraConnected = new ReplaySubject<void>(1)
   readonly onCallAnswered = new ReplaySubject<string>(1)
-  readonly onCallEnded = new ReplaySubject<void>(1)
+  readonly onCallEnded = new ReplaySubject<
+    { code: number; text: string } | undefined
+  >(1)
   readonly onError = new ReplaySubject<void>(1)
   readonly onMessage = new ReplaySubject<{ method: string }>()
   readonly onWsOpen
@@ -224,7 +226,7 @@ export class WebrtcConnection extends Subscribed {
       case 'close':
         logError('Video stream closed')
         logError(message.body)
-        this.callEnded()
+        this.callEnded(message.body.reason)
         return
       case 'camera_started':
       case 'stream_info':
@@ -305,7 +307,7 @@ export class WebrtcConnection extends Subscribed {
   }
 
   private hasEnded = false
-  private callEnded() {
+  private callEnded(reason?: { code: number; text: string }) {
     if (this.hasEnded) {
       return
     }
@@ -322,7 +324,7 @@ export class WebrtcConnection extends Subscribed {
     this.hasEnded = true
 
     this.unsubscribe()
-    this.onCallEnded.next()
+    this.onCallEnded.next(reason)
     this.pc.close()
   }
 

--- a/packages/ring-client-api/test/streaming-session.spec.ts
+++ b/packages/ring-client-api/test/streaming-session.spec.ts
@@ -1,0 +1,84 @@
+import { ReplaySubject, Subject } from 'rxjs'
+import type { RtpPacket } from 'werift'
+import { describe, expect, it, vi } from 'vitest'
+import { StreamingSession } from '../streaming/streaming-session.ts'
+
+function createConnection() {
+  return {
+    onAudioRtp: new Subject<RtpPacket>(),
+    onVideoRtp: new Subject<RtpPacket>(),
+    onCallAnswered: new ReplaySubject<string>(1),
+    onCallEnded: new ReplaySubject<{ code: number; text: string } | undefined>(
+      1,
+    ),
+    onError: new ReplaySubject<void>(1),
+    activateCameraSpeaker: vi.fn(),
+    requestKeyFrame: vi.fn(),
+    sendAudioPacket: vi.fn(),
+    stop: vi.fn(),
+  }
+}
+
+function createRtp(sequenceNumber: number, timestamp: number) {
+  return {
+    header: { sequenceNumber, timestamp },
+    payload: Buffer.alloc(0),
+  } as RtpPacket
+}
+
+describe('StreamingSession', () => {
+  it('keeps RTP continuous and requests a key frame after answered_timeout', async () => {
+    const initialConnection = createConnection(),
+      replacementConnection = createConnection(),
+      createReplacement = vi.fn().mockResolvedValue(replacementConnection),
+      session = new StreamingSession(
+        { name: 'Front Door' } as any,
+        initialConnection as any,
+        createReplacement,
+      ),
+      packets: RtpPacket[] = []
+
+    session.onVideoRtp.subscribe((packet) => packets.push(packet))
+    initialConnection.onVideoRtp.next(createRtp(40000, 90000))
+    initialConnection.onVideoRtp.next(createRtp(40001, 93000))
+    initialConnection.onCallEnded.next({
+      code: 10,
+      text: 'answered_timeout',
+    })
+
+    await vi.waitFor(() => expect(createReplacement).toHaveBeenCalledOnce())
+
+    replacementConnection.onCallAnswered.next('v=0')
+    replacementConnection.onVideoRtp.next(createRtp(100, 5000))
+    replacementConnection.onVideoRtp.next(createRtp(101, 8000))
+
+    expect(
+      packets.map(({ header }) => [header.sequenceNumber, header.timestamp]),
+    ).toEqual([
+      [40000, 90000],
+      [40001, 93000],
+      [40002, 96000],
+      [40003, 99000],
+    ])
+    expect(replacementConnection.requestKeyFrame).toHaveBeenCalledOnce()
+
+    session.stop()
+  })
+
+  it('ends instead of reconnecting for other close reasons', () => {
+    const connection = createConnection(),
+      createReplacement = vi.fn(),
+      session = new StreamingSession(
+        { name: 'Front Door' } as any,
+        connection as any,
+        createReplacement,
+      ),
+      ended = vi.fn()
+
+    session.onCallEnded.subscribe(ended)
+    connection.onCallEnded.next({ code: 9, text: 'answered_timeout' })
+
+    expect(createReplacement).not.toHaveBeenCalled()
+    expect(ended).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Summary

Ring closes answered live-view sessions after roughly 30 minutes with reason code `10` / `answered_timeout`. This change reconnects the Ring WebRTC transport for that reason only while keeping the existing `StreamingSession` alive for consumers such as HomeKit.

The replacement transport starts its RTP sequence numbers and timestamps from a new origin. The session maps those values onto the existing continuous timeline so HomeKit's established SRTP stream accepts the replacement video. It also requests a key frame when the replacement call is answered. Other close reasons retain the existing behavior and end the stream.

## Verification

Targeted tests cover reconnect, RTP continuity, the key-frame request, and non-timeout close behavior. The full `ring-client-api` test suite and both `ring-client-api` and `homebridge-ring` builds pass.

A 35-minute end-to-end test on Homebridge 2.4.0 / homebridge-ring 14.3.0 crossed the real Ring timeout boundary successfully. At 30 minutes Ring returned code `10` / `answered_timeout`; Homebridge reconnected in the same second, and the existing Home video view continued for more than five additional minutes without a delayed stop.