### PR TITLE
fix(ring-client-api): handle non-JSON oauth error responses

### DIFF
--- a/.changeset/fix-non-json-oauth-error.md
+++ b/.changeset/fix-non-json-oauth-error.md
@@ -1,0 +1,5 @@
+---
+"ring-client-api": patch
+---
+
+Fix a `TypeError` in `getAuth()` when the oauth endpoint returns a non-JSON error body (for example a `406 Not Acceptable` HTML page); the failure is now reported as `(error: HTTP 406)`.

--- a/packages/ring-client-api/rest-client.ts
+++ b/packages/ring-client-api/rest-client.ts
@@ -364,10 +364,15 @@ export class RingRestClient {
       }
 
       const response = requestError.response || {},
-        responseData: Auth2faResponse = response.body || {},
+        responseData: Auth2faResponse =
+          typeof response.body === 'object' && response.body !== null
+            ? response.body
+            : {},
         responseError =
           'error' in responseData && typeof responseData.error === 'string'
             ? responseData.error
+            : response.status
+            ? `HTTP ${response.status}`
             : ''
 
       if (

--- a/packages/ring-client-api/test/rest-client.spec.ts
+++ b/packages/ring-client-api/test/rest-client.spec.ts
@@ -209,6 +209,7 @@ afterAll(() => {
 })
 
 afterEach(() => {
+  server.resetHandlers()
   client.clearTimeouts()
   clearTimeouts()
 })
@@ -256,6 +257,25 @@ describe('getAuth', () => {
 
     await expect(() => client.getAuth()).rejects.toThrow(
       'Failed to fetch oauth token from Ring. Verify that your email and password are correct. (error: access_denied)',
+    )
+  })
+
+  it('should handle a non-json error response', async () => {
+    server.use(
+      http.post('https://oauth.ring.com/oauth/token', () =>
+        HttpResponse.text(
+          '<html><head><title>406 Not Acceptable</title></head></html>',
+          { status: 406 },
+        ),
+      ),
+    )
+    client = new RingRestClient({
+      password,
+      email,
+    })
+
+    await expect(() => client.getAuth()).rejects.toThrow(
+      'Failed to fetch oauth token from Ring. Verify that your email and password are correct. (error: HTTP 406)',
     )
   })
 


### PR DESCRIPTION
Closes #1817 

A non-JSON body from the OAuth endpoint (`406 Not Acceptable` HTML page) makes `getAuth()` throw `TypeError: Cannot use 'in' operator to search for 'error'` from its own error handler. Same crash reported in #1193.

The body is now only treated as JSON when it is an object, and `responseError` falls back to `HTTP <status>`. 

That fallback also applies to JSON error bodies with no string `error` field, which used to end in `(error: )`.

The new test uses `server.use`, so `afterEach` now calls `server.resetHandlers()`.

**Relevant to #1704**: it relocates this block ahead of the refresh-token branch, which would expose refresh-token clients to the same crash.