### PR TITLE
fix(ring-client-api): subscribe intercoms to ding events on every session

### DIFF
--- a/.changeset/intercom-ding-subscription.md
+++ b/.changeset/intercom-ding-subscription.md
@@ -1,0 +1,5 @@
+---
+"ring-client-api": patch
+---
+
+Subscribe Ring Intercoms to ding events on every session instead of only when the api reports no existing subscription. The `subscribed` flag can be stale — the api reports an existing subscription while it is still bound to a push token that is no longer registered, so no ding notifications are delivered and the client never re-subscribes. Cameras already subscribe this way; intercoms now follow the same pattern and are disconnected with their location.

--- a/packages/ring-client-api/location.ts
+++ b/packages/ring-client-api/location.ts
@@ -619,6 +619,7 @@ export class Location extends Subscribed {
     this.disconnected = true
     this.unsubscribe()
     this.cameras.forEach((camera) => camera.disconnect())
+    this.intercoms.forEach((intercom) => intercom.disconnect())
     this.getDevices()
       .then((devices) => {
         devices.forEach((device) => device.disconnect())

--- a/packages/ring-client-api/ring-intercom.ts
+++ b/packages/ring-client-api/ring-intercom.ts
@@ -3,11 +3,17 @@ import { PushNotificationAction } from './ring-types.ts'
 import type { RingRestClient } from './rest-client.ts'
 import { clientApi, commandsApi } from './rest-client.ts'
 import { BehaviorSubject, Subject } from 'rxjs'
-import { distinctUntilChanged, map } from 'rxjs/operators'
+import {
+  distinctUntilChanged,
+  map,
+  startWith,
+  throttleTime,
+} from 'rxjs/operators'
 import { getBatteryLevel } from './ring-camera.ts'
+import { Subscribed } from './subscribed.ts'
 import { logError } from './util.ts'
 
-export class RingIntercom {
+export class RingIntercom extends Subscribed {
   id
   deviceType
   onData
@@ -19,6 +25,8 @@ export class RingIntercom {
   private restClient
 
   constructor(initialData: IntercomHandsetData, restClient: RingRestClient) {
+    super()
+
     this.initialData = initialData
     this.restClient = restClient
     this.id = initialData.id
@@ -30,14 +38,20 @@ export class RingIntercom {
       distinctUntilChanged(),
     )
 
-    if (!initialData.subscribed) {
-      this.subscribeToDingEvents().catch((e) => {
-        logError(
-          'Failed to subscribe ' + initialData.description + ' to ding events',
-        )
-        logError(e)
-      })
-    }
+    this.addSubscriptions(
+      this.restClient.onSession
+        .pipe(startWith(undefined), throttleTime(1000)) // Force this to run immediately, but don't double run if a session is created due to these api calls
+        .subscribe(() => {
+          this.subscribeToDingEvents().catch((e) => {
+            logError(
+              'Failed to subscribe ' +
+                initialData.description +
+                ' to ding events',
+            )
+            logError(e)
+          })
+        }),
+    )
   }
 
   updateData(update: IntercomHandsetData) {
@@ -113,5 +127,9 @@ export class RingIntercom {
     ) {
       this.onUnlocked.next()
     }
+  }
+
+  disconnect() {
+    this.unsubscribe()
   }
 }

--- a/packages/ring-client-api/test/ring-intercom.spec.ts
+++ b/packages/ring-client-api/test/ring-intercom.spec.ts
@@ -1,0 +1,75 @@
+import { Subject } from 'rxjs'
+import { describe, expect, it, vi } from 'vitest'
+import { RingIntercom } from '../ring-intercom.ts'
+import type { RingRestClient } from '../rest-client.ts'
+import type { IntercomHandsetData } from '../ring-types.ts'
+
+function createRestClient() {
+  const onSession = new Subject<undefined>(),
+    request = vi.fn().mockResolvedValue(undefined),
+    restClient = { onSession, request } as unknown as RingRestClient
+
+  return { onSession, request, restClient }
+}
+
+function createIntercomData(subscribed: boolean) {
+  return {
+    id: 123,
+    kind: 'intercom_handset_audio',
+    description: 'Front Door',
+    subscribed,
+    battery_life: 100,
+    alerts: { connection: 'online' },
+  } as unknown as IntercomHandsetData
+}
+
+const subscribeRequest = {
+  method: 'POST',
+  url: expect.stringContaining('doorbots/123/subscribe'),
+}
+
+describe('Ring Intercom', () => {
+  describe('ding event subscription', () => {
+    it('subscribes to ding events on creation', () => {
+      const { request, restClient } = createRestClient()
+
+      new RingIntercom(createIntercomData(false), restClient)
+
+      expect(request).toHaveBeenCalledWith(subscribeRequest)
+    })
+
+    it('subscribes even when the api reports an existing subscription', () => {
+      // The `subscribed` flag can be stale: the api reports an existing
+      // subscription while it is still bound to a push token that is no longer
+      // registered, in which case no ding notifications are delivered.
+      const { request, restClient } = createRestClient()
+
+      new RingIntercom(createIntercomData(true), restClient)
+
+      expect(request).toHaveBeenCalledWith(subscribeRequest)
+    })
+
+    it('subscribes again when a new session is created', () => {
+      vi.useFakeTimers()
+
+      try {
+        const { onSession, request, restClient } = createRestClient()
+
+        new RingIntercom(createIntercomData(true), restClient)
+        expect(request).toHaveBeenCalledTimes(1)
+
+        // Throttled, so a session created by these api calls does not double up
+        onSession.next(undefined)
+        expect(request).toHaveBeenCalledTimes(1)
+
+        vi.advanceTimersByTime(1100)
+        onSession.next(undefined)
+
+        expect(request).toHaveBeenCalledTimes(2)
+        expect(request).toHaveBeenLastCalledWith(subscribeRequest)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+})


### PR DESCRIPTION
## The problem

`RingIntercom` subscribes to ding events exactly once, and only if the api happens to report that there is no subscription yet:

```ts
if (!initialData.subscribed) {
  this.subscribeToDingEvents().catch(...)
}
```

That flag can be stale. On a Ring Intercom that stopped delivering dings to HomeKit, the api reported `subscribed: true` on every single startup, while no ding notification was ever delivered — the subscription was still bound to a push token that had long since been replaced. Because the flag stays `true`, the client never re-subscribes, and no amount of restarting helps.

`RingCamera` does not have this problem, because it re-subscribes on every session:

```ts
this.addSubscriptions(
  this.restClient.onSession
    .pipe(startWith(undefined), throttleTime(1000))
    .subscribe(() => {
      this.subscribeToDingEvents().catch(...)
      this.subscribeToMotionEvents().catch(...)
    }),
)
```

That also fixes an ordering detail: the push token is registered with `PATCH /clients_api/device` while devices are being set up, so a one-shot subscribe in the constructor can bind whatever token was current a moment earlier. Re-subscribing per session avoids depending on that order.

## What this PR changes

- `RingIntercom` extends `Subscribed` and subscribes to ding events through the same `onSession` / `startWith` / `throttleTime(1000)` pipeline cameras use — unconditionally, so a stale `subscribed` flag can no longer suppress it
- adds `RingIntercom.disconnect()` and calls it from `Location.disconnect()` next to the cameras, so the new subscription is cleaned up like every other one
- adds `test/ring-intercom.spec.ts`

No api surface is removed: `subscribeToDingEvents()` / `unsubscribeFromDingEvents()` are untouched, and one extra idempotent POST per session is the only behaviour change for setups that were already working.

## Tests

`test/ring-intercom.spec.ts` covers three cases: subscribing on creation, subscribing when the api reports `subscribed: true`, and re-subscribing when a new session is created. Against `main` without this change, the last two fail:

```
❯ test/ring-intercom.spec.ts (3 tests | 2 failed)
  × subscribes even when the api reports an existing subscription
  × subscribes again when a new session is created
```

With the change, `turbo run build test lint --filter=ring-client-api` is green (18 existing + 3 new tests).

## Background

Found while tracking down why a Ring Intercom no longer triggered the HomePod doorbell chime through homebridge-ring: the plugin received no push notifications at all, while the Ring app rang normally. The stale `subscribed: true` was one of the defects on that path — measured with byte counters on the MTALK socket, so a missing ding is distinguishable from a ding that arrives and is dropped later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVUFgtojQrWQcsoVMz5r6w
