### PR TITLE
fix(homebridge): log when the refreshToken could not be persisted to config.json

### DIFF
--- a/.changeset/warn-refresh-token-not-persisted.md
+++ b/.changeset/warn-refresh-token-not-persisted.md
@@ -1,0 +1,5 @@
+---
+"homebridge-ring": patch
+---
+
+Log an error when an updated `refreshToken` could not be written to config.json. `updateHomebridgeConfig` replaces the previous token as a string and returns whether anything changed, but the return value was ignored — if the token in the file does not match the previous token byte for byte, the update silently does nothing and the config keeps a token that will eventually stop working.

--- a/packages/homebridge-ring/ring-platform.ts
+++ b/packages/homebridge-ring/ring-platform.ts
@@ -39,7 +39,7 @@ import { Switch } from './switch.ts'
 import { Camera } from './camera.ts'
 import { PanicButtons } from './panic-buttons.ts'
 import type { RefreshTokenAuth } from 'ring-client-api/rest-client'
-import { logInfo, useLogger } from 'ring-client-api/util'
+import { logError, logInfo, useLogger } from 'ring-client-api/util'
 import type { BaseAccessory } from './base-accessory.ts'
 import { FloodFreezeSensor } from './flood-freeze-sensor.ts'
 import { FreezeSensor } from './freeze-sensor.ts'
@@ -394,9 +394,18 @@ export class RingPlatform implements DynamicPlatformPlugin {
           return
         }
 
-        updateHomebridgeConfig(this.api, (configContents) => {
+        const updated = updateHomebridgeConfig(this.api, (configContents) => {
           return configContents.replace(oldRefreshToken, newRefreshToken)
         })
+
+        if (!updated) {
+          // The previous token was not found in config.json, so it could not be
+          // replaced. This is silent otherwise, and leaves a stale token behind
+          // that will eventually stop working.
+          logError(
+            'Failed to store the updated refreshToken in config.json: the previous token was not found in the file. Please update the Ring refreshToken in your config manually.',
+          )
+        }
       },
     )
   }


### PR DESCRIPTION
## The problem

`updateHomebridgeConfig()` replaces the previous refresh token as a plain string and returns whether the file actually changed:

```ts
if (config !== updatedConfig) {
  writeFileSync(configPath, updatedConfig)
  return true
}

return false
```

The caller in `ring-platform.ts` ignores that return value:

```ts
updateHomebridgeConfig(this.api, (configContents) => {
  return configContents.replace(oldRefreshToken, newRefreshToken)
})
```

If the token in config.json does not match `oldRefreshToken` byte for byte, `replace()` matches nothing, the file is left untouched, and nothing is logged. Every later rotation hits the same mismatch, so the config keeps a token that is never updated again — invisible until authentication eventually fails after a restart.

The token is a base64 encoded JSON blob that the client re-serializes with `JSON.stringify` (`toBase64(JSON.stringify(this.authConfig))`), so a config whose token was written by anything else — an editor, a script, a different JSON serializer — encodes the same data as a different string. That is enough to break persistence silently.

## How I hit it

While debugging a Ring Intercom that stopped delivering ding notifications, I rewrote the `refreshToken` in config.json with a small Python script (same data, `json.dumps` puts spaces after `,` and `:`). From that moment the plugin created fresh push notification credentials on every restart and none of them were ever persisted — no error, no warning, nothing in the log. Only after the Homebridge UI wrote a token again did persistence resume. Two hours of my debugging went into that silence.

## What this PR changes

Logs an error when the update did not apply:

```
Failed to store the updated refreshToken in config.json: the previous token was
not found in the file. Please update the Ring refreshToken in your config manually.
```

That is the whole change — no behaviour change on the happy path, and the plugin keeps running exactly as before. `turbo run build lint --filter=homebridge-ring` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVUFgtojQrWQcsoVMz5r6w
